### PR TITLE
Use config file class

### DIFF
--- a/addons/mod_tool/build_zip.gd
+++ b/addons/mod_tool/build_zip.gd
@@ -58,6 +58,10 @@ func _get_imported_file_path(store: ModToolStore, import_file_path: String) -> S
 	# Get the path to the imported file
 	# Imported file example path:
 	# res://.import/ImportedPNG.png-eddc81c8e2d2fc90950be5862656c2b5.stex
-	var imported_file_path := config.get_value('remap', 'path') as String
+	var imported_file_path := config.get_value('remap', 'path', '') as String
+
+	if imported_file_path == '':
+		ModToolUtils.output_error(store, "No remap path found in import file -> " + import_file_path)
+		return ''
 
 	return imported_file_path

--- a/addons/mod_tool/build_zip.gd
+++ b/addons/mod_tool/build_zip.gd
@@ -27,23 +27,20 @@ func build_zip(store: ModToolStore) -> void:
 	# Generate temp folder that get's zipped later
 	for i in store.path_mod_files.size():
 		var path_mod_file := store.path_mod_files[i] as String
+		var path_zip_file := store.path_temp_dir + '/' + path_mod_file.trim_prefix("res://")
 
-		# Copy mod_file to path_zip_file
-		ModToolUtils.file_copy(path_mod_file, store.path_temp_dir + '/' + path_mod_file.trim_prefix("res://"))
+		# Copy mod_file to temp folder
+		ModToolUtils.file_copy(path_mod_file, path_zip_file)
 
 	# Zip that folder with 7zip
-	var path_addon_dir := ProjectSettings.globalize_path(store.path_project_dir + "addons/mod_tool/")
-	var path_seven_zip := path_addon_dir + "vendor/7zip/win/zip.exe"
-	var path_final_zip := path_addon_dir + "zips/" + store.name_mod_dir + ".zip"
-	var path_global_temp_dir := ProjectSettings.globalize_path(store.path_temp_dir)
-	var path_global_temp_dir_with_wildcard := path_global_temp_dir + "/*"
+	var path_global_temp_dir_with_wildcard: String = store.path_global_temp_dir + "/*"
 
 	var output := []
-	var _exit_code := OS.execute(path_seven_zip, ["a", path_final_zip, path_global_temp_dir_with_wildcard], true, output)
+	var _exit_code := OS.execute(store.path_global_seven_zip, ["a", store.path_global_final_zip, path_global_temp_dir_with_wildcard], true, output)
 	store.label_output.add_text(JSON.print(output, '   '))
 
 	# Delete the temp folder
-	ModToolUtils.remove_recursive(path_global_temp_dir)
+	ModToolUtils.remove_recursive(store.path_global_temp_dir)
 
 
 func _get_imported_file_path(store: ModToolStore, import_file_path: String) -> String:
@@ -51,7 +48,6 @@ func _get_imported_file_path(store: ModToolStore, import_file_path: String) -> S
 
 	# Open file
 	var error := config.load(import_file_path)
-
 	if error != OK:
 		ModToolUtils.output_error(store, "Failed to load import file -> " + str(error))
 

--- a/addons/mod_tool/build_zip.gd
+++ b/addons/mod_tool/build_zip.gd
@@ -22,13 +22,13 @@ func build_zip(store: ModToolStore) -> void:
 			var path_imported_file := _get_imported_file_path(store, path_mod_file)
 			# And add it to the mod file paths
 			if not path_imported_file == "":
-				store.path_mod_files.append("res://" + path_imported_file)
+				store.path_mod_files.append(path_imported_file)
 
 	# Generate temp folder that get's zipped later
 	for i in store.path_mod_files.size():
 		var path_mod_file := store.path_mod_files[i] as String
 
-		# copy mod_file to path_zip_file
+		# Copy mod_file to path_zip_file
 		ModToolUtils.file_copy(path_mod_file, store.path_temp_dir + '/' + path_mod_file.trim_prefix("res://"))
 
 	# Zip that folder with 7zip
@@ -46,36 +46,18 @@ func build_zip(store: ModToolStore) -> void:
 	ModToolUtils.remove_recursive(path_global_temp_dir)
 
 
-# TODO: Rework this to use [ConfigFile]
-# https://docs.godotengine.org/en/stable/classes/class_configfile.html
 func _get_imported_file_path(store: ModToolStore, import_file_path: String) -> String:
+	var config := ConfigFile.new()
+
 	# Open file
-	var text := ModToolUtils.file_get_as_text(import_file_path)
+	var error := config.load(import_file_path)
+
+	if error != OK:
+		ModToolUtils.output_error(store, "Failed to load import file -> " + str(error))
 
 	# Get the path to the imported file
-	var path_imported_file_regex_results := ModToolUtils.get_regex_results(text, "res\\:\\/\\/\\.import.+?(?=\\\")")
-	if(path_imported_file_regex_results.size() == 0):
-		print("ERROR: No path found inside .import file! import_file_path -> " + import_file_path)
-		return ""
-
-	# Grab the first path to the imported file
 	# Imported file example path:
 	# res://.import/ImportedPNG.png-eddc81c8e2d2fc90950be5862656c2b5.stex
-	var imported_file_src_path_local := path_imported_file_regex_results[0] as String
-	# remove the res://
-	imported_file_src_path_local = imported_file_src_path_local.replace('res://', '')
-	# Globalize the path:
-	# C:\Path\to\GodotProject\.import\ImportedPNG.png-eddc81c8e2d2fc90950be5862656c2b5.stex
-	var imported_file_src_path := str(store.path_project_dir, imported_file_src_path_local)
+	var imported_file_path := config.get_value('remap', 'path') as String
 
-	# Get the imported file dst file - the dst path is local to the zip file
-	# Imported file dst path example:
-	# \.import\ImportedPNG.png-eddc81c8e2d2fc90950be5862656c2b5.stex
-
-	# ['C:\Path\to\GodotProject\', '\ImportedPNG.png-eddc81c8e2d2fc90950be5862656c2b5.stex']
-	var imported_file_src_path_split := imported_file_src_path.split('.import')
-	var imported_file_local_path := imported_file_src_path_split[1]
-
-	var imported_file_dst_path := str('.import', imported_file_local_path)
-
-	return imported_file_dst_path
+	return imported_file_path

--- a/addons/mod_tool/dock.gd
+++ b/addons/mod_tool/dock.gd
@@ -2,8 +2,6 @@ tool
 extends Control
 
 
-const ERROR_COLOR = "#ff9090"
-
 # passed from the EditorPlugin
 var editor_interface: EditorInterface setget set_editor_interface
 var base_theme: Theme
@@ -118,12 +116,12 @@ func _update_ui():
 func _is_mod_dir_valid() -> bool:
 	# Check if Mod ID is given
 	if store.name_mod_dir == '':
-		label_output.append_bbcode("\n [color=%s]ERROR: Please provide a Mod ID[/color]" % ERROR_COLOR)
+		ModToolUtils.output_error(store, "Please provide a Mod ID")
 		return false
 
 	# Check if mod dir exists
 	if not ModLoaderUtils.dir_exists(store.path_mod_dir):
-		label_output.append_bbcode("\n [color=%s]ERROR: Mod folder %s does not exist[/color]" % [ERROR_COLOR, store.path_mod_dir])
+		ModToolUtils.output_error(store, "Mod folder %s does not exist" % store.path_mod_dir)
 		return false
 
 	return true

--- a/addons/mod_tool/store.gd
+++ b/addons/mod_tool/store.gd
@@ -5,6 +5,7 @@ class_name ModToolStore
 # Global store for all Data the ModTool requires.
 
 const PATH_SAVE_FILE := "user://mod-tool-plugin-save.json"
+const ERROR_COLOR = "#ff9090"
 
 var name_mod_dir := "" setget set_name_mod_dir
 var path_mod_dir := ""

--- a/addons/mod_tool/store.gd
+++ b/addons/mod_tool/store.gd
@@ -10,12 +10,17 @@ const ERROR_COLOR = "#ff9090"
 var name_mod_dir := "" setget set_name_mod_dir
 var path_mod_dir := ""
 var path_export_dir := ""
-var path_project_dir := ""
 var path_temp_dir := ""
-var excluded_file_extensions : PoolStringArray = [".csv.import"]
-var path_mod_files : Array = []
+var path_global_export_dir := ""
+var path_global_project_dir := ""
+var path_global_temp_dir := ""
+var path_global_addon_dir := ""
+var path_global_seven_zip := ""
+var path_global_final_zip := ""
+var excluded_file_extensions: PoolStringArray = [".csv.import"]
+var path_mod_files: Array = []
 
-var label_output : RichTextLabel
+var label_output: RichTextLabel
 
 
 func set_name_mod_dir(new_name_mod_dir: String) -> void:
@@ -25,9 +30,14 @@ func set_name_mod_dir(new_name_mod_dir: String) -> void:
 func init(store: Dictionary) -> void:
 	name_mod_dir = store.name_mod_dir
 	path_mod_dir = "res://mods-unpacked/" + store.name_mod_dir
-	path_export_dir = "res://zips"
-	path_project_dir = ProjectSettings.globalize_path(ModLoaderUtils.get_local_folder_dir())
+	path_export_dir = "res://zips/"
+	path_global_export_dir = ProjectSettings.globalize_path(path_export_dir)
+	path_global_project_dir = ProjectSettings.globalize_path(ModLoaderUtils.get_local_folder_dir())
 	path_temp_dir = "user://temp/" + store.name_mod_dir
+	path_global_temp_dir = ProjectSettings.globalize_path(path_temp_dir)
+	path_global_addon_dir = path_global_project_dir + "addons/mod_tool/"
+	path_global_seven_zip = path_global_addon_dir + "vendor/7zip/win/zip.exe"
+	path_global_final_zip = path_global_export_dir + store.name_mod_dir + ".zip"
 	excluded_file_extensions = [".csv.import"]
 
 
@@ -42,7 +52,7 @@ func save_store() -> void:
 		"name_mod_dir": name_mod_dir,
 		"path_mod_dir": path_mod_dir,
 		"path_export_dir": path_export_dir,
-		"path_project_dir": path_project_dir,
+		"path_global_project_dir": path_global_project_dir,
 		"path_temp_dir": path_temp_dir,
 		"excluded_file_extensions": excluded_file_extensions
 	}

--- a/addons/mod_tool/utils.gd
+++ b/addons/mod_tool/utils.gd
@@ -61,6 +61,11 @@ static func file_copy(src: String, dst: String) -> void:
 	file.close()
 
 
+# Log error message to the output richtext label.
+static func output_error(store: ModToolStore, message: String) -> void:
+	store.label_output.append_bbcode("\n [color=%s]ERROR: %s[/color]" % [store.ERROR_COLOR, message])
+
+
 # Takes a directory path to get removed.
 # https://www.davidepesce.com/2019/11/04/essential-guide-to-godot-filesystem-api/
 static func remove_recursive(path: String) -> void:


### PR DESCRIPTION
- Reworked `_get_imported_file_path()` to use `ConfigFile` Class
- Added `output_error()` to `ModToolUtils`
- Moved `ERROR_COLOR` const from *dock.gd* to *store.gd*
- Moved most paths used in `build_zip()` to *store.gd*