### PR TITLE
refactor: :recycle: moved editor base theme to store.gd

### DIFF
--- a/addons/mod_tool/dock.gd
+++ b/addons/mod_tool/dock.gd
@@ -4,7 +4,6 @@ extends Control
 
 # passed from the EditorPlugin
 var editor_interface: EditorInterface setget set_editor_interface
-var base_theme: Theme
 var store: ModToolStore = ModToolStore.new()
 
 var tab_parent_bottom_panel: PanelContainer
@@ -29,20 +28,19 @@ func _ready() -> void:
 
 func set_editor_interface(interface: EditorInterface) -> void:
 	editor_interface = interface
-	base_theme = editor_interface.get_base_control().theme
-	store.error_color = "#" + base_theme.get_color("error_color", "Editor").to_html()
+	store.base_theme = editor_interface.get_base_control().theme
 
-	$TabContainer.add_stylebox_override("panel", base_theme.get_stylebox("DebuggerPanel", "EditorStyles"))
+	$TabContainer.add_stylebox_override("panel", store.base_theme.get_stylebox("DebuggerPanel", "EditorStyles"))
 
 	# set up warning icons to show if a field is invalid
 	for node in $"TabContainer/Mod Manifest/ScrollContainer/VBox".get_children():
 		if node.has_method("set_error_icon"):
-			node.set_error_icon(base_theme.get_icon("NodeWarning", "EditorIcons"))
+			node.set_error_icon(store.base_theme.get_icon("NodeWarning", "EditorIcons"))
 
 	store.label_output = label_output
 
 	$"%ConfigEditor".editor_settings = editor_interface.get_editor_settings()
-	$"%ConfigEditor".base_theme = base_theme
+	$"%ConfigEditor".base_theme = store.base_theme
 
 
 func get_log_nodes() -> void:
@@ -162,14 +160,14 @@ func _on_mod_skeleton_pressed() -> void:
 # this is to offset the 10px content margins that are still present in the
 # BottomPanelDebuggerOverride stylebox for some reason. It's how Godot does it.
 func _on_mod_tools_dock_visibility_changed() -> void:
-	if not visible or not base_theme or not tab_parent_bottom_panel:
+	if not visible or not store.base_theme or not tab_parent_bottom_panel:
 		return
 
 	# the panel style is overridden by godot after this method is called
 	# make sure our override-override is applied after that
 	yield(get_tree(), "idle_frame")
 
-	var panel_box: StyleBoxFlat = base_theme.get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")
+	var panel_box: StyleBoxFlat = store.base_theme.get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")
 	tab_parent_bottom_panel.add_stylebox_override("panel", panel_box)
 
 

--- a/addons/mod_tool/dock.tscn
+++ b/addons/mod_tool/dock.tscn
@@ -48,6 +48,7 @@ margin_right = 10.0
 tab_align = 0
 
 [node name="Export" type="PanelContainer" parent="TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -208,7 +209,6 @@ margin_bottom = 44.0
 text = "Generate Mod Skeleton"
 
 [node name="Mod Manifest" type="PanelContainer" parent="TabContainer"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -219,14 +219,14 @@ margin_bottom = -4.0
 [node name="ScrollContainer" type="ScrollContainer" parent="TabContainer/Mod Manifest"]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 1925.0
-margin_bottom = 1037.0
+margin_right = 1029.0
+margin_bottom = 557.0
 size_flags_vertical = 3
 follow_focus = true
 scroll_horizontal_enabled = false
 
 [node name="VBox" type="VBoxContainer" parent="TabContainer/Mod Manifest/ScrollContainer"]
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 572.0
 size_flags_horizontal = 3
 __meta__ = {
@@ -234,7 +234,7 @@ __meta__ = {
 }
 
 [node name="Category" type="LineEdit" parent="TabContainer/Mod Manifest/ScrollContainer/VBox"]
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 24.0
 mouse_filter = 2
 mouse_default_cursor_shape = 0
@@ -248,17 +248,17 @@ middle_mouse_paste_enabled = false
 
 [node name="HBoxContainer" type="HBoxContainer" parent="TabContainer/Mod Manifest/ScrollContainer/VBox"]
 margin_top = 28.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 48.0
 
 [node name="Control" type="Control" parent="TabContainer/Mod Manifest/ScrollContainer/VBox/HBoxContainer"]
-margin_right = 1765.0
+margin_right = 857.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 
 [node name="SaveManifest" type="Button" parent="TabContainer/Mod Manifest/ScrollContainer/VBox/HBoxContainer"]
-margin_left = 1769.0
-margin_right = 1918.0
+margin_left = 861.0
+margin_right = 1010.0
 margin_bottom = 20.0
 text = "Save to manifest.json"
 
@@ -266,7 +266,7 @@ text = "Save to manifest.json"
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 52.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 76.0
 hint_tooltip = "Name of the Mod.
 Only letters, numbers and underscores allowed."
@@ -280,7 +280,7 @@ Only letters, numbers and underscores allowed."
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 80.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 104.0
 hint_tooltip = "Namespace of the Mod.
 Often just the main author or team name.
@@ -296,7 +296,7 @@ Only letters, numbers and underscores allowed."
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 108.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 132.0
 hint_tooltip = "Semantic version string.
 Only integers and periods allowed.
@@ -315,7 +315,7 @@ For reference, see https://semver.org"
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 136.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 160.0
 hint_tooltip = "URL for your website or repository."
 mouse_default_cursor_shape = 16
@@ -327,7 +327,7 @@ hint_text = "URL for your website or repository."
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 164.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 188.0
 hint_tooltip = "Comma-separated list of mod IDs.
 Only letters, numbers and underscores allowed.
@@ -345,13 +345,13 @@ Format: {namespace}-{name}"
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 192.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 404.0
 label_text = "Description"
 
 [node name="Category2" type="LineEdit" parent="TabContainer/Mod Manifest/ScrollContainer/VBox"]
 margin_top = 408.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 432.0
 mouse_filter = 2
 mouse_default_cursor_shape = 0
@@ -367,7 +367,7 @@ middle_mouse_paste_enabled = false
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 436.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 460.0
 hint_tooltip = "Comma-separated list of Authors"
 mouse_default_cursor_shape = 16
@@ -379,7 +379,7 @@ hint_text = "Comma-separated list of Authors"
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 464.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 488.0
 hint_tooltip = "Comma-separated list of mod IDs.
 Only letters, numbers and underscores allowed.
@@ -397,7 +397,7 @@ Format: {namespace}-{name}"
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 492.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 516.0
 hint_tooltip = "Comma-separated list of valid game versions."
 mouse_default_cursor_shape = 16
@@ -409,7 +409,7 @@ hint_text = "Comma-separated list of valid game versions."
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 520.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 544.0
 hint_tooltip = "Comma-separated list of ModLoader versions."
 mouse_default_cursor_shape = 16
@@ -421,7 +421,7 @@ hint_text = "Comma-separated list of ModLoader versions."
 unique_name_in_owner = true
 anchor_right = 0.0
 margin_top = 548.0
-margin_right = 1918.0
+margin_right = 1010.0
 margin_bottom = 572.0
 hint_tooltip = "Compatible ModLoader Versions"
 mouse_default_cursor_shape = 16

--- a/addons/mod_tool/store.gd
+++ b/addons/mod_tool/store.gd
@@ -6,6 +6,7 @@ class_name ModToolStore
 
 const PATH_SAVE_FILE := "user://mod-tool-plugin-save.json"
 
+var base_theme: Theme setget set_base_theme
 var error_color := ''
 
 var name_mod_dir := "" setget set_name_mod_dir
@@ -22,6 +23,11 @@ var excluded_file_extensions: PoolStringArray = [".csv.import"]
 var path_mod_files: Array = []
 
 var label_output: RichTextLabel
+
+
+func set_base_theme(new_base_theme: Theme) -> void:
+	base_theme = new_base_theme
+	error_color = "#" + base_theme.get_color("error_color", "Editor").to_html()
 
 
 func set_name_mod_dir(new_name_mod_dir: String) -> void:


### PR DESCRIPTION
Moved editor base theme to store.gd so it's easier to access.

I left the *json_editor.gd* as is. Because it uses a set function on the `base_theme` var.