### PR TITLE
refactor: :recycle: Add / Remove ModToolStore as a singleton/autoload

### DIFF
--- a/addons/mod_tool/build_zip.gd
+++ b/addons/mod_tool/build_zip.gd
@@ -2,54 +2,56 @@ extends Node
 class_name ModToolZipBuilder
 
 
-func build_zip(store: ModToolStore) -> void:
+func build_zip() -> void:
 	# Get all file paths inside the mod folder
-	store.path_mod_files = ModToolUtils.get_flat_view_dict(store.path_mod_dir)
-	store.label_output.add_text(JSON.print(store.path_mod_files, '   '))
+	ModToolStore.path_mod_files = ModToolUtils.get_flat_view_dict(ModToolStore.path_mod_dir)
+	ModToolStore.label_output.add_text(JSON.print(ModToolStore.path_mod_files, '   '))
 
 	# Loop over each file path
-	for i in store.path_mod_files.size():
-		var path_mod_file := store.path_mod_files[i] as String
+	print(JSON.print(ModToolStore.path_mod_files, '\t'))
+	print(JSON.print(ModToolStore.path_mod_files.size(), '\t'))
+	for i in ModToolStore.path_mod_files.size():
+		var path_mod_file := ModToolStore.path_mod_files[i] as String
 		# Check for excluded file extensions
-		if ModToolUtils.is_file_extension(path_mod_file, store.excluded_file_extensions):
+		if ModToolUtils.is_file_extension(path_mod_file, ModToolStore.excluded_file_extensions):
 			# Dont add files with unwanted extensions to the zip
-			store.path_mod_files.remove(i)
+			ModToolStore.path_mod_files.remove(i)
 			continue
 
 		# If it's a .import file
 		if path_mod_file.get_extension() == "import":
 			# Get the path to the imported file
-			var path_imported_file := _get_imported_file_path(store, path_mod_file)
+			var path_imported_file := _get_imported_file_path(path_mod_file)
 			# And add it to the mod file paths
 			if not path_imported_file == "":
-				store.path_mod_files.append(path_imported_file)
+				ModToolStore.path_mod_files.append(path_imported_file)
 
 	# Generate temp folder that get's zipped later
-	for i in store.path_mod_files.size():
-		var path_mod_file := store.path_mod_files[i] as String
-		var path_zip_file := store.path_temp_dir + '/' + path_mod_file.trim_prefix("res://")
+	for i in ModToolStore.path_mod_files.size():
+		var path_mod_file := ModToolStore.path_mod_files[i] as String
+		var path_zip_file := ModToolStore.path_temp_dir + '/' + path_mod_file.trim_prefix("res://")
 
 		# Copy mod_file to temp folder
 		ModToolUtils.file_copy(path_mod_file, path_zip_file)
 
 	# Zip that folder with 7zip
-	var path_global_temp_dir_with_wildcard: String = store.path_global_temp_dir + "/*"
+	var path_global_temp_dir_with_wildcard: String = ModToolStore.path_global_temp_dir + "/*"
 
 	var output := []
-	var _exit_code := OS.execute(store.path_global_seven_zip, ["a", store.path_global_final_zip, path_global_temp_dir_with_wildcard], true, output)
-	store.label_output.add_text(JSON.print(output, '   '))
+	var _exit_code := OS.execute(ModToolStore.path_global_seven_zip, ["a", ModToolStore.path_global_final_zip, path_global_temp_dir_with_wildcard], true, output)
+	ModToolStore.label_output.add_text(JSON.print(output, '   '))
 
 	# Delete the temp folder
-	ModToolUtils.remove_recursive(store.path_global_temp_dir)
+	ModToolUtils.remove_recursive(ModToolStore.path_global_temp_dir)
 
 
-func _get_imported_file_path(store: ModToolStore, import_file_path: String) -> String:
+func _get_imported_file_path(import_file_path: String) -> String:
 	var config := ConfigFile.new()
 
 	# Open file
 	var error := config.load(import_file_path)
 	if error != OK:
-		ModToolUtils.output_error(store, "Failed to load import file -> " + str(error))
+		ModToolUtils.output_error("Failed to load import file -> " + str(error))
 
 	# Get the path to the imported file
 	# Imported file example path:
@@ -57,7 +59,7 @@ func _get_imported_file_path(store: ModToolStore, import_file_path: String) -> S
 	var imported_file_path := config.get_value('remap', 'path', '') as String
 
 	if imported_file_path == '':
-		ModToolUtils.output_error(store, "No remap path found in import file -> " + import_file_path)
+		ModToolUtils.output_error("No remap path found in import file -> " + import_file_path)
 		return ''
 
 	return imported_file_path

--- a/addons/mod_tool/dock.gd
+++ b/addons/mod_tool/dock.gd
@@ -16,7 +16,6 @@ onready var mod_id := $"%ModId"
 func _ready() -> void:
 	tab_parent_bottom_panel = get_parent().get_parent() as PanelContainer
 
-	ModToolStore.load_store()
 	ModToolStore.label_output = label_output
 
 	_load_manifest()

--- a/addons/mod_tool/plugin.gd
+++ b/addons/mod_tool/plugin.gd
@@ -5,14 +5,14 @@ var dock: Control
 
 
 func _enter_tree() -> void:
+	add_autoload_singleton('ModToolStore', "res://addons/mod_tool/store.gd")
 	dock = preload("res://addons/mod_tool/dock.tscn").instance()
 	dock.editor_interface = get_editor_interface()
 	dock.editor_interface = get_editor_interface()
-	dock.store.load_store()
 	add_control_to_bottom_panel(dock, 'Mod Tool')
 
 
 func _exit_tree() -> void:
-	dock.store.save_store()
+	remove_autoload_singleton('ModToolStore')
 	remove_control_from_bottom_panel(dock)
 	dock.free()

--- a/addons/mod_tool/store.gd
+++ b/addons/mod_tool/store.gd
@@ -1,5 +1,5 @@
+tool
 extends Node
-class_name ModToolStore
 
 
 # Global store for all Data the ModTool requires.
@@ -52,6 +52,7 @@ func update_paths(new_name_mod_dir: String) -> void:
 	name_mod_dir = new_name_mod_dir
 	path_mod_dir = "res://mods-unpacked/" + new_name_mod_dir
 	path_temp_dir = "user://temp/" + new_name_mod_dir
+	path_global_temp_dir = ProjectSettings.globalize_path(path_temp_dir)
 
 
 func save_store() -> void:

--- a/addons/mod_tool/store.gd
+++ b/addons/mod_tool/store.gd
@@ -25,11 +25,11 @@ var path_mod_files: Array = []
 var label_output: RichTextLabel
 
 
-func _ready():
+func _ready() -> void:
 	load_store()
 
 
-func _exit_tree():
+func _exit_tree() -> void:
 	save_store()
 
 

--- a/addons/mod_tool/store.gd
+++ b/addons/mod_tool/store.gd
@@ -25,6 +25,14 @@ var path_mod_files: Array = []
 var label_output: RichTextLabel
 
 
+func _ready():
+	load_store()
+
+
+func _exit_tree():
+	save_store()
+
+
 func set_base_theme(new_base_theme: Theme) -> void:
 	base_theme = new_base_theme
 	error_color = "#" + base_theme.get_color("error_color", "Editor").to_html()

--- a/addons/mod_tool/utils.gd
+++ b/addons/mod_tool/utils.gd
@@ -51,8 +51,8 @@ static func file_copy(src: String, dst: String) -> void:
 
 
 # Log error message to the output richtext label.
-static func output_error(store: ModToolStore, message: String) -> void:
-	store.label_output.append_bbcode("\n [color=%s]ERROR: %s[/color]" % [store.error_color, message])
+static func output_error(message: String) -> void:
+	ModToolStore.label_output.append_bbcode("\n [color=%s]ERROR: %s[/color]" % [ModToolStore.error_color, message])
 
 
 # Takes a directory path to get removed.


### PR DESCRIPTION
Adding the ModToolStore as a singleton on `_enter_tree()` in *plugin.gd* allows easy access from any where in the plugin. Refactored every store reference to use the new singleton. The singleton get's removed in `_exit_tree()` in *plugin.gd*.