### PR TITLE
refactor: change input actions to reference to avoid freeing

### DIFF
--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -1,5 +1,5 @@
 class_name FileSystemContextActions
-extends Object
+extends Reference
 
 var base_theme: Theme
 

--- a/addons/mod_tool/plugin.gd
+++ b/addons/mod_tool/plugin.gd
@@ -1,7 +1,7 @@
 tool
 extends EditorPlugin
 
-var tools_panel: Control
+var tools_panel: ModToolsPanel
 
 
 func _enter_tree() -> void:
@@ -15,7 +15,6 @@ func _enter_tree() -> void:
 
 func _exit_tree() -> void:
 	if tools_panel:
-		tools_panel.context_actions.free()
 		tools_panel.free()
 
 	remove_autoload_singleton('ModToolStore')


### PR DESCRIPTION
Reference will be freed automatically if there are no references to it anywhere