### PR TITLE
refactor: :recycle: hide the config editor for now

### DIFF
--- a/addons/mod_tool/interface/config_editor/ModConfigEditor.tscn
+++ b/addons/mod_tool/interface/config_editor/ModConfigEditor.tscn
@@ -1,0 +1,78 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/mod_tool/interface/config_editor/json_editor.gd" type="Script" id=1]
+
+[node name="Mod Config Editor" type="PanelContainer"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = 24.0
+
+[node name="VBox" type="VBoxContainer" parent="."]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 1907.0
+margin_bottom = 891.0
+
+[node name="HBox" type="HBoxContainer" parent="VBox"]
+margin_right = 1900.0
+margin_bottom = 40.0
+
+[node name="Label" type="Label" parent="VBox/HBox"]
+margin_top = 13.0
+margin_right = 1533.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+text = "Default json for user mod configuration"
+
+[node name="ErrorLabel" type="Label" parent="VBox/HBox"]
+unique_name_in_owner = true
+margin_left = 1537.0
+margin_top = 13.0
+margin_right = 1617.0
+margin_bottom = 27.0
+text = "JSON is valid"
+
+[node name="ShouldValidate" type="CheckButton" parent="VBox/HBox"]
+unique_name_in_owner = true
+margin_left = 1621.0
+margin_right = 1697.0
+margin_bottom = 40.0
+pressed = true
+flat = true
+
+[node name="VSeparator" type="VSeparator" parent="VBox/HBox"]
+margin_left = 1701.0
+margin_right = 1705.0
+margin_bottom = 40.0
+
+[node name="SaveConfig" type="Button" parent="VBox/HBox"]
+margin_left = 1709.0
+margin_right = 1900.0
+margin_bottom = 40.0
+text = "Save config to manifest.json"
+
+[node name="ConfigEditor" type="TextEdit" parent="VBox"]
+unique_name_in_owner = true
+margin_top = 44.0
+margin_right = 1900.0
+margin_bottom = 884.0
+size_flags_vertical = 3
+text = "{
+
+}"
+highlight_current_line = true
+syntax_highlighting = true
+show_line_numbers = true
+fold_gutter = true
+highlight_all_occurrences = true
+smooth_scrolling = true
+hiding_enabled = true
+script = ExtResource( 1 )
+
+[node name="ValidationDelay" type="Timer" parent="VBox/ConfigEditor"]
+one_shot = true
+
+[connection signal="cursor_changed" from="VBox/ConfigEditor" to="VBox/ConfigEditor" method="_on_cursor_changed"]
+[connection signal="text_changed" from="VBox/ConfigEditor" to="VBox/ConfigEditor" method="_on_text_changed"]
+[connection signal="timeout" from="VBox/ConfigEditor/ValidationDelay" to="VBox/ConfigEditor" method="_on_ValidationDelay_timeout"]

--- a/addons/mod_tool/interface/panel/tools_panel.tscn
+++ b/addons/mod_tool/interface/panel/tools_panel.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/mod_tool/interface/create_mod/create_mod.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/mod_tool/interface/manifest_editor/manifest_editor.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/mod_tool/interface/panel/tools_panel.gd" type="Script" id=3]
 [ext_resource path="res://addons/mod_tool/interface/global/input_string.tscn" type="PackedScene" id=4]
-[ext_resource path="res://addons/mod_tool/interface/config_editor/json_editor.gd" type="Script" id=5]
 [ext_resource path="res://addons/mod_tool/interface/global/input_options.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/mod_tool/interface/global/directory_selection/select_directory.tscn" type="PackedScene" id=7]
 
@@ -71,77 +70,6 @@ tab_align = 0
 
 [node name="Manifest Editor" parent="Panel/VSplit/TabContainer" instance=ExtResource( 2 )]
 margin_top = 24.0
-
-[node name="Mod Config Editor" type="PanelContainer" parent="Panel/VSplit/TabContainer"]
-visible = false
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_top = 24.0
-
-[node name="VBox" type="VBoxContainer" parent="Panel/VSplit/TabContainer/Mod Config Editor"]
-margin_left = 7.0
-margin_top = 7.0
-margin_right = 1907.0
-margin_bottom = 891.0
-
-[node name="HBox" type="HBoxContainer" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox"]
-margin_right = 1900.0
-margin_bottom = 40.0
-
-[node name="Label" type="Label" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox/HBox"]
-margin_top = 13.0
-margin_right = 1533.0
-margin_bottom = 27.0
-size_flags_horizontal = 3
-text = "Default json for user mod configuration"
-
-[node name="ErrorLabel" type="Label" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox/HBox"]
-unique_name_in_owner = true
-margin_left = 1537.0
-margin_top = 13.0
-margin_right = 1617.0
-margin_bottom = 27.0
-text = "JSON is valid"
-
-[node name="ShouldValidate" type="CheckButton" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox/HBox"]
-unique_name_in_owner = true
-margin_left = 1621.0
-margin_right = 1697.0
-margin_bottom = 40.0
-pressed = true
-flat = true
-
-[node name="VSeparator" type="VSeparator" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox/HBox"]
-margin_left = 1701.0
-margin_right = 1705.0
-margin_bottom = 40.0
-
-[node name="SaveConfig" type="Button" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox/HBox"]
-margin_left = 1709.0
-margin_right = 1900.0
-margin_bottom = 40.0
-text = "Save config to manifest.json"
-
-[node name="ConfigEditor" type="TextEdit" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox"]
-unique_name_in_owner = true
-margin_top = 44.0
-margin_right = 1900.0
-margin_bottom = 884.0
-size_flags_vertical = 3
-text = "{
-
-}"
-highlight_current_line = true
-syntax_highlighting = true
-show_line_numbers = true
-fold_gutter = true
-highlight_all_occurrences = true
-smooth_scrolling = true
-hiding_enabled = true
-script = ExtResource( 5 )
-
-[node name="ValidationDelay" type="Timer" parent="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor"]
-one_shot = true
 
 [node name="Export" type="PanelContainer" parent="Panel/VSplit"]
 margin_top = 426.0
@@ -240,7 +168,7 @@ hint_text = "ID of the mod to be exported.
 Format: Namespace-ModName
 (Often Author-ModName)"
 is_editable = false
-input_text = ""
+input_text = "test05-test05"
 
 [node name="ExportPath" parent="Panel/VSplit/Export/HSplit/Settings/VBox" instance=ExtResource( 4 )]
 unique_name_in_owner = true
@@ -321,7 +249,6 @@ text = "Connect existing Mod"
 
 [node name="CreateMod" parent="." instance=ExtResource( 1 )]
 unique_name_in_owner = true
-visible = false
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 340.0
@@ -336,10 +263,6 @@ window_title = "Connect existing Mod"
 unique_name_in_owner = true
 window_title = "Select Mod Template"
 
-[connection signal="pressed" from="Panel/VSplit/TabContainer/Mod Config Editor/VBox/HBox/SaveConfig" to="." method="_on_save_config_pressed"]
-[connection signal="cursor_changed" from="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor" to="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor" method="_on_cursor_changed"]
-[connection signal="text_changed" from="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor" to="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor" method="_on_text_changed"]
-[connection signal="timeout" from="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor/ValidationDelay" to="Panel/VSplit/TabContainer/Mod Config Editor/VBox/ConfigEditor" method="_on_ValidationDelay_timeout"]
 [connection signal="pressed" from="Panel/VSplit/Export/HSplit/Console/HBox/CopyOutput" to="." method="_on_copy_output_pressed"]
 [connection signal="pressed" from="Panel/VSplit/Export/HSplit/Console/HBox/ClearOutput" to="." method="_on_clear_output_pressed"]
 [connection signal="pressed" from="Panel/VSplit/Export/HSplit/Settings/VBox/Align/Export" to="." method="_on_export_pressed"]


### PR DESCRIPTION
- Moved the Config Editor into a separate scene
- Temporarily removed the Config Editor tab from the UI until #56 is implemented.

works towards #6