### PR TITLE
refactor: :recycle: hide the export type option for now

### DIFF
--- a/addons/mod_tool/interface/panel/tools_panel.tscn
+++ b/addons/mod_tool/interface/panel/tools_panel.tscn
@@ -259,6 +259,7 @@ Format: Namespace-ModName
 
 [node name="ExportType" parent="Panel/VSplit/Export/HSplit/Settings/VBox" instance=ExtResource( 6 )]
 unique_name_in_owner = true
+visible = false
 anchor_right = 0.0
 margin_top = 100.0
 margin_right = 692.0


### PR DESCRIPTION
- Temporarily hide the Export Types until #39 is implemented.

closes #61