### PR TITLE
feat: :sparkles: Open Script Editor after script extension creation

### DIFF
--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -137,6 +137,8 @@ func file_system_context_menu_pressed(id: int, context_menu: PopupMenu) -> void:
 			if extension_path:
 				add_script_extension_to_mod_main(extension_path)
 		ModToolStore.editor_plugin.get_editor_interface().get_script_editor().reload_scripts()
+		# Switch to the script screen
+		ModToolStore.editor_plugin.get_editor_interface().set_main_screen_editor("Script")
 
 	if metadata is Dictionary and metadata.has("mod_tool_override_paths"):
 		file_paths = metadata.mod_tool_override_paths
@@ -164,8 +166,13 @@ static func create_script_extension(file_path: String) -> String:
 		file.close()
 		ModToolUtils.output_info('Created script extension of "%s" at path %s' % [file_path.get_file(), extension_path])
 
+
 	ModToolStore.editor_file_system.scan()
 	ModToolStore.editor_plugin.get_editor_interface().get_file_system_dock().navigate_to_path(extension_path)
+	# Load the new extension script
+	var extension_script: Script = load(extension_path)
+	# Open the ne extension script in the script editor
+	ModToolStore.editor_plugin.get_editor_interface().edit_script(extension_script)
 
 	return extension_path
 

--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -166,7 +166,6 @@ static func create_script_extension(file_path: String) -> String:
 		file.close()
 		ModToolUtils.output_info('Created script extension of "%s" at path %s' % [file_path.get_file(), extension_path])
 
-
 	ModToolStore.editor_file_system.scan()
 	ModToolStore.editor_plugin.get_editor_interface().get_file_system_dock().navigate_to_path(extension_path)
 	# Load the new extension script


### PR DESCRIPTION
Open the script editor automatically after creating a script extension. This deviates from the planned implementation discussed in #47, as it does not focus on the first selected script but simply opens them in order. This simplification was made to avoid unnecessary complexity. Since in most cases only one script at a time will be extended, the additional complexity is not worth it.

closes #47