### PR TITLE
fix: :bug: fixed context actions not working

### DIFF
--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -2,13 +2,14 @@ class_name FileSystemContextActions
 extends Node
 
 
-onready var mod_tool_store: ModToolStore = get_node_or_null("/root/ModToolStore")
+var mod_tool_store: ModToolStore
 var base_theme: Theme
 
 
-func _init(file_system_dock: FileSystemDock, p_base_theme: Theme) -> void:
-	base_theme = p_base_theme
+func _init(_mod_tool_store: ModToolStore, file_system_dock: FileSystemDock, p_base_theme: Theme) -> void:
+	mod_tool_store = _mod_tool_store
 	connect_file_system_context_actions(file_system_dock)
+	base_theme = p_base_theme
 
 
 func connect_file_system_context_actions(file_system_dock: FileSystemDock) -> void:

--- a/addons/mod_tool/interface/panel/tools_panel.gd
+++ b/addons/mod_tool/interface/panel/tools_panel.gd
@@ -45,6 +45,7 @@ func set_editor_plugin(plugin: EditorPlugin) -> void:
 	mod_tool_store.editor_file_system = editor_plugin.get_editor_interface().get_resource_filesystem()
 
 	context_actions = FileSystemContextActions.new(
+		mod_tool_store,
 		editor_plugin.get_editor_interface().get_file_system_dock(),
 		editor_plugin.get_editor_interface().get_base_control().theme
 	)


### PR DESCRIPTION
pass the `mod_tool_store` when initializing the `FileSystemContextActions`

closes #81