### PR TITLE
fix: :bug: clear manifest inputs if no data present

### DIFF
--- a/addons/mod_tool/interface/manifest_editor/manifest_editor.gd
+++ b/addons/mod_tool/interface/manifest_editor/manifest_editor.gd
@@ -49,6 +49,9 @@ func update_ui() -> void:
 			# Else convert the value to a string
 			else:
 				input.input_text = str(value)
+		# If the key is not in the data clear the input
+		else:
+			input.input_text = ""
 
 
 # Returns an array of invalid fields

--- a/addons/mod_tool/interface/manifest_editor/manifest_editor.tscn
+++ b/addons/mod_tool/interface/manifest_editor/manifest_editor.tscn
@@ -326,11 +326,11 @@ anchor_right = 0.0
 margin_top = 668.0
 margin_right = 990.0
 margin_bottom = 700.0
-hint_tooltip = "Compatible ModLoader Versions"
+hint_tooltip = "Comma-separated list of tags that describe your mod.."
 mouse_default_cursor_shape = 16
 key = "tags"
 label_text = "Tags"
-hint_text = "Compatible ModLoader Versions"
+hint_text = "Comma-separated list of tags that describe your mod.."
 input_placeholder = "Tag1, Tag2"
 
 [connection signal="pressed" from="VBox/HBox2/SaveManifest" to="." method="_on_SaveManifest_pressed"]


### PR DESCRIPTION
Fixed a bug where, after switching mods, the manifest editor would display fields from the previous mod if the current mod had no data for those inputs, resulting in the data from the previous mod being shown.

closes #89