### PR TITLE
fix: :bug: fixed export zip name after mod switch

### DIFF
--- a/addons/mod_tool/global/store.gd
+++ b/addons/mod_tool/global/store.gd
@@ -103,6 +103,7 @@ func update_paths(new_name_mod_dir: String) -> void:
 	path_temp_dir = "user://temp/" + new_name_mod_dir
 	path_global_temp_dir = ProjectSettings.globalize_path(path_temp_dir)
 	path_manifest = path_mod_dir + "/manifest.json"
+	path_global_final_zip =  "%s/%s.zip" % [path_global_export_dir, name_mod_dir]
 
 
 func save_store() -> void:


### PR DESCRIPTION
After switching mods via "Connect existing Mod," the path `path_global_final_zip` was not updated, resulting in the wrong zip name on export.

closes #90