### PR TITLE
fix: :bug: template selection with only default templates

### DIFF
--- a/addons/mod_tool/interface/create_mod/create_mod.gd
+++ b/addons/mod_tool/interface/create_mod/create_mod.gd
@@ -104,14 +104,12 @@ func get_template_options() -> PoolStringArray:
 		):
 			continue
 
-		# Add the default templates
-		mod_template_options.push_back(DIR_NAME_DEFAULT_TEMPLATE)
-		mod_template_options.push_back(DIR_NAME_MINIMAL_TEMPLATE)
-
 		# Add all the custom templates
 		mod_template_options.push_back(template_dir_name)
 
-
+	# Add the default templates
+	mod_template_options.push_back(DIR_NAME_DEFAULT_TEMPLATE)
+	mod_template_options.push_back(DIR_NAME_MINIMAL_TEMPLATE)
 
 	return mod_template_options as PoolStringArray
 


### PR DESCRIPTION
Fixed template selection not showing anything if only default templates are present.

closes #99 