### PR TITLE
feat: :sparkles: mod hook gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 addons/mod_tool/vendor/7zip/mac/*
 addons/mod_tool/vendor/7zip/windows/*
 addons/mod_tool/vendor/7zip/linux/*
+addons/mod_tool/.script_backup
 

--- a/addons/mod_tool/global/store.gd
+++ b/addons/mod_tool/global/store.gd
@@ -47,6 +47,9 @@ var mod_hook_preprocessor := _ModLoaderModHookPreProcessor.new()
 func _ready() -> void:
 	load_store()
 
+	if not DirAccess.dir_exists_absolute(path_script_backup_dir):
+		create_script_backup_dir()
+
 
 func _exit_tree() -> void:
 	save_store()
@@ -91,17 +94,17 @@ func init(store: Dictionary) -> void:
 	mod_hook_preprocessor.hashmap = JSON.parse_string(store.mod_hook_preprocessor_hashmap)
 
 
-	if not DirAccess.dir_exists_absolute(path_script_backup_dir):
-		DirAccess.make_dir_recursive_absolute(path_script_backup_dir)
-		FileAccess.open("%s/.gdignore" % path_script_backup_dir, FileAccess.WRITE)
-
-
 func update_paths(new_name_mod_dir: String) -> void:
 	path_mod_dir = "res://mods-unpacked/" + new_name_mod_dir
 	path_temp_dir = "user://temp/" + new_name_mod_dir
 	path_global_temp_dir = ProjectSettings.globalize_path(path_temp_dir)
 	path_manifest = path_mod_dir + "/manifest.json"
 	path_global_final_zip =  "%s/%s.zip" % [path_global_export_dir, name_mod_dir]
+
+
+func create_script_backup_dir() -> void:
+	DirAccess.make_dir_recursive_absolute(path_script_backup_dir)
+	FileAccess.open("%s/.gdignore" % path_script_backup_dir, FileAccess.WRITE)
 
 
 func save_store() -> void:

--- a/addons/mod_tool/global/store.gd
+++ b/addons/mod_tool/global/store.gd
@@ -89,7 +89,7 @@ func init(store: Dictionary) -> void:
 
 	path_global_final_zip = "%s/%s.zip" % [path_global_export_dir, name_mod_dir]
 	excluded_file_extensions = []
-	is_hook_generation_done = store.is_hook_generation_done if store.is_hook_generation_done else false
+	is_hook_generation_done = store.is_hook_generation_done
 	hooked_scripts = JSON.parse_string(store.hooked_scripts)
 	mod_hook_preprocessor.hashmap = JSON.parse_string(store.mod_hook_preprocessor_hashmap)
 

--- a/addons/mod_tool/global/store.gd
+++ b/addons/mod_tool/global/store.gd
@@ -34,6 +34,7 @@ var path_mod_files := []
 var current_os := ""
 var is_seven_zip_installed := true
 var pending_reloads: Array[String] = []
+var is_hook_generation_done := false
 
 # ModManifest instance
 var manifest_data : ModManifest
@@ -82,6 +83,7 @@ func init(store: Dictionary) -> void:
 
 	path_global_final_zip = "%s/%s.zip" % [path_global_export_dir, name_mod_dir]
 	excluded_file_extensions = []
+	is_hook_generation_done = store.is_hook_generation_done if store.is_hook_generation_done else false
 
 
 func update_paths(new_name_mod_dir: String) -> void:
@@ -100,7 +102,8 @@ func save_store() -> void:
 		"path_export_dir": path_export_dir,
 		"path_global_project_dir": path_global_project_dir,
 		"path_temp_dir": path_temp_dir,
-		"excluded_file_extensions": excluded_file_extensions
+		"excluded_file_extensions": excluded_file_extensions,
+		"is_hook_generation_done": is_hook_generation_done
 	}
 
 	var file := FileAccess.open(PATH_SAVE_FILE, FileAccess.WRITE)

--- a/addons/mod_tool/interface/create_mod/create_mod.gd
+++ b/addons/mod_tool/interface/create_mod/create_mod.gd
@@ -34,7 +34,7 @@ func add_mod() -> void:
 			return
 
 		# Get Template files
-		var template_paths := ModToolUtils.get_flat_view_dict(mod_tool_store.path_current_template_dir, "", false, true)
+		var template_paths := ModToolUtils.get_flat_view_dict(mod_tool_store.path_current_template_dir, "", [], false, true)
 
 		# Copy current selected template dir files and folders to res://mods-unpacked
 		for path in template_paths:

--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -106,7 +106,7 @@ func add_custom_context_actions(context_menu: PopupMenu, file_paths: PackedStrin
 
 		# Add Hooks Context Action
 		context_menu.add_icon_item(
-			mod_tool_store.editor_base_control.get_theme_icon(&"Edit", &"EditorIcons"),
+			mod_tool_store.editor_base_control.get_theme_icon(&"ScriptCreate", &"EditorIcons"),
 			"ModTool: Add Mod Hooks" + ("s (%s)" % script_paths.size() if script_paths.size() > 1 else "")
 		)
 		context_menu.set_item_metadata(

--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -3,7 +3,7 @@ extends Control
 
 
 var mod_tool_store: ModToolStore
-var mod_hook_pre_processor := ModLoaderModHookPreProcessor.new()
+var mod_hook_pre_processor := _ModLoaderModHookPreProcessor.new()
 
 func _init(_mod_tool_store: ModToolStore, file_system_dock: FileSystemDock) -> void:
 	mod_tool_store = _mod_tool_store

--- a/addons/mod_tool/interface/file_system/file_system_context_actions.gd
+++ b/addons/mod_tool/interface/file_system/file_system_context_actions.gd
@@ -3,7 +3,22 @@ extends Control
 
 
 var mod_tool_store: ModToolStore
-var mod_hook_pre_processor := _ModLoaderModHookPreProcessor.new()
+
+
+class ContextActionOptions:
+	extends Resource
+
+	var icon: StringName
+	var title: String
+	var meta_key: StringName
+	var tooltip: String
+
+	func _init(_icon, _title, _meta_key, _tooltip) -> void:
+		icon = _icon
+		title = _title
+		meta_key = _meta_key
+		tooltip = _tooltip
+
 
 func _init(_mod_tool_store: ModToolStore, file_system_dock: FileSystemDock) -> void:
 	mod_tool_store = _mod_tool_store
@@ -25,7 +40,7 @@ func connect_file_system_context_actions(file_system : FileSystemDock) -> void:
 		if not context_menu:
 			continue
 
-		context_menu.id_pressed.connect(file_system_context_menu_pressed.bind(context_menu))
+		context_menu.id_pressed.connect(_on_file_system_context_menu_pressed.bind(context_menu))
 
 		var signals := context_menu.get_signal_connection_list(&"id_pressed")
 		if not signals.is_empty():
@@ -36,43 +51,14 @@ func connect_file_system_context_actions(file_system : FileSystemDock) -> void:
 					context_menu.about_to_popup.connect(_on_file_list_context_actions_about_to_popup.bind(context_menu, file_tree))
 
 
-func _on_file_tree_context_actions_about_to_popup(context_menu: PopupMenu, tree: Tree) -> void:
-	var selected := tree.get_next_selected(null)
-	if not selected:		# Empty space was clicked
-		return
-
-	# multiselection
-	var file_paths := []
-	while selected:
-		var file_path = selected.get_metadata(0)
-		if file_path is String:
-			file_paths.append(file_path)
-		selected = tree.get_next_selected(selected)
-
-	add_custom_context_actions(context_menu, file_paths)
-
-
-func _on_file_list_context_actions_about_to_popup(context_menu: PopupMenu, list: ItemList) -> void:
-	if not list.get_selected_items().size() > 0:		# Empty space was clicked
-		return
-
-	var file_paths := []
-	for item_index in list.get_selected_items():
-		var file_path = list.get_item_metadata(item_index)
-		if file_path is String:
-			file_paths.append(file_path)
-
-	add_custom_context_actions(context_menu, file_paths)
-
-
 # Called every time the file system context actions pop up
 # Since they are dynamic, they are cleared every time and need to be refilled
-func add_custom_context_actions(context_menu: PopupMenu, file_paths: PackedStringArray) -> void:
+func add_custom_context_actions(context_menu: PopupMenu, file_paths: Array[String]) -> void:
 	if file_paths.is_empty():
 		return
 
-	var script_paths := []
-	var asset_override_paths := []
+	var script_paths: Array[String] = []
+	var asset_override_paths: Array[String] = []
 	for file_path in file_paths:
 		if DirAccess.dir_exists_absolute(file_path):
 			continue
@@ -89,112 +75,20 @@ func add_custom_context_actions(context_menu: PopupMenu, file_paths: PackedStrin
 		context_menu.add_separator()
 
 	if script_paths.size() > 0:
-		# Script Extension Context Action
-		context_menu.add_icon_item(
-			mod_tool_store.editor_base_control.get_theme_icon(&"ScriptExtend", &"EditorIcons"),
-			"ModTool: Create Script Extension" + ("s (%s)" % script_paths.size() if script_paths.size() > 1 else "")
-		)
-		context_menu.set_item_metadata(
-			context_menu.get_item_count() -1,
-			{ "mod_tool_script_paths": script_paths }
-		)
-		context_menu.set_item_tooltip(
-			context_menu.get_item_count() -1,
-			"Will add extensions for: \n%s" %
-			str(script_paths).trim_prefix("[").trim_suffix("]").replace(", ", "\n")
-		)
+		add_script_extension_context_action(context_menu, script_paths)
 
-		# Add Hooks Context Action
-		context_menu.add_icon_item(
-			mod_tool_store.editor_base_control.get_theme_icon(&"ScriptCreate", &"EditorIcons"),
-			"ModTool: Add Mod Hooks" + ("s (%s)" % script_paths.size() if script_paths.size() > 1 else "")
-		)
-		context_menu.set_item_metadata(
-			context_menu.get_item_count() -1,
-			{ "mod_tool_hook_script_paths": script_paths }
-		)
-		context_menu.set_item_tooltip(
-			context_menu.get_item_count() -1,
-			"Will add mod hooks for: \n%s" %
-			str(script_paths).trim_prefix("[").trim_suffix("]").replace(", ", "\n")
-		)
+		var script_with_hook_count := ModToolUtils.check_for_hooked_script(script_paths, mod_tool_store)
+
+		if script_with_hook_count == script_paths.size():
+			add_restore_context_action(context_menu, script_paths)
+		elif script_with_hook_count > 0:
+			add_restore_context_action(context_menu, script_paths)
+			add_hooks_context_action(context_menu, script_paths)
+		else:
+			add_hooks_context_action(context_menu, script_paths)
 
 	if asset_override_paths.size() > 0:
-		context_menu.add_icon_item(
-
-			mod_tool_store.editor_base_control.get_theme_icon(&"Override", &"EditorIcons"),
-			"ModTool: Create Asset Overwrite" + ("s (%s)" % asset_override_paths.size() if asset_override_paths.size() > 1 else "")
-		)
-		context_menu.set_item_metadata(
-			context_menu.get_item_count() -1,
-			{ "mod_tool_override_paths": asset_override_paths }
-		)
-		context_menu.set_item_tooltip(
-			context_menu.get_item_count() -1,
-			"Will overwrite assets: \n%s" %
-			str(asset_override_paths).trim_prefix("[").trim_suffix("]").replace(", ", "\n")
-		)
-
-
-func file_system_context_menu_pressed(id: int, context_menu: PopupMenu) -> void:
-	var file_paths: PackedStringArray
-	var metadata = context_menu.get_item_metadata(id)
-	var current_script: GDScript
-
-	# Ensure that the metadata is actually set by the ModTool
-	# Since id and index of the item can always change
-	if metadata is Dictionary and metadata.has("mod_tool_script_paths"):
-		var mod_main_path := mod_tool_store.path_mod_dir.path_join("mod_main.gd")
-
-		file_paths = metadata.mod_tool_script_paths
-		for file_path in file_paths:
-			var extension_path := create_script_extension(file_path)
-			if extension_path:
-				add_script_extension_to_mod_main(extension_path)
-
-		# We navigate to the created script extension in `create_script_extension()`, so we should never
-		# instantly refresh the mod main script here. If we call `ModToolUtils.reload_script()`
-		# after this, it's possible that the `mod_main` content gets copied into the
-		# newly created extension script. If that script is then saved, we
-		# unintentionally overwrite the original script content.
-		mod_tool_store.pending_reloads.push_back(mod_main_path)
-
-		 #Switch to the script screen
-		EditorInterface.set_main_screen_editor("Script")
-
-	if metadata is Dictionary and metadata.has("mod_tool_override_paths"):
-		var overwrites_path := mod_tool_store.path_mod_dir.path_join("overwrites.gd")
-
-		file_paths = metadata.mod_tool_override_paths
-		for file_path in file_paths:
-			var asset_path := create_overwrite_asset(file_path)
-			if asset_path:
-				add_asset_overwrite_to_overwrites(file_path, asset_path)
-
-		current_script = EditorInterface.get_script_editor().get_current_script()
-
-		mod_tool_store.pending_reloads.push_back(overwrites_path)
-
-		if current_script.resource_path == overwrites_path:
-			ModToolUtils.reload_script(current_script, mod_tool_store)
-
-		#Switch to the script screen
-		EditorInterface.set_main_screen_editor("Script")
-
-	if metadata is Dictionary and metadata.has("mod_tool_hook_script_paths"):
-		file_paths = metadata.mod_tool_hook_script_paths
-
-		for file_path in file_paths:
-			var source_code := mod_hook_pre_processor.process_script(file_path)
-			var file := FileAccess.open(file_path, FileAccess.WRITE)
-
-			# TODO: Create a backup before changing the script file
-			if file:
-				file.resize(0)
-				file.store_string(source_code)
-				ModToolUtils.output_info("Created hooks for %s" % file_path)
-			else:
-				ModToolUtils.output_error("Error opening script %s" % file_path)
+		add_asset_override_context_action(context_menu, script_paths)
 
 
 func create_script_extension(file_path: String) -> String:
@@ -229,7 +123,7 @@ func add_script_extension_to_mod_main(extension_path: String) -> void:
 	var file := FileAccess.open(main_script_path, FileAccess.READ_WRITE)
 	if not file:
 		ModToolUtils.output_error("Failed to open mod_main.gd with error \"%s\"" % error_string(FileAccess.get_open_error()))
-	if not script_has_method(main_script_path, "install_script_extensions"):
+	if not ModToolUtils.script_has_method(main_script_path, "install_script_extensions"):
 		ModToolUtils.output_error('To automatically add new script extensions to "mod_main.gd", add the method "install_script_extensions" to it.')
 		return
 
@@ -242,10 +136,10 @@ func add_script_extension_to_mod_main(extension_path: String) -> void:
 	# variable "extensions_dir_path" is found, use that variable in combination with path_join
 	var extension_install_line := "\tModLoaderMod.install_script_extension(%s)\n"
 	if mod_extensions_dir_path_index == -1:
-		extension_install_line = extension_install_line % quote_string(extension_path)
+		extension_install_line = extension_install_line % ModToolUtils.quote_string(extension_path)
 	else:
 		extension_path = extension_path.trim_prefix(mod_tool_store.path_mod_dir.path_join("extensions/"))
-		extension_install_line = extension_install_line % "extensions_dir_path.path_join(%s)" % quote_string(extension_path)
+		extension_install_line = extension_install_line % "extensions_dir_path.path_join(%s)" % ModToolUtils.quote_string(extension_path)
 
 	# Check if that file was already used as script extension
 	if extension_install_line.strip_edges() in file_content:
@@ -254,7 +148,7 @@ func add_script_extension_to_mod_main(extension_path: String) -> void:
 	var last_install_line_index := file_content.rfind("ModLoaderMod.install_script_extension")
 	if last_install_line_index == -1:
 		# If there is no ModLoaderMod.install_script_extension yet, put it at the end of install_script_extensions
-		var insertion_index := get_index_at_method_end("install_script_extensions", file_content)
+		var insertion_index := ModToolUtils.get_index_at_method_end("install_script_extensions", file_content)
 		file_content = file_content.insert(insertion_index, "\n" + extension_install_line)
 	else:
 		var last_install_line_end_index := file_content.find("\n", last_install_line_index)
@@ -287,36 +181,10 @@ func create_overwrite_asset(file_path: String) -> String:
 	return overwrite_path
 
 
-static func get_index_at_method_end(method_name: String, text: String) -> int:
-	var starting_index := text.rfind(method_name)
-
-	# Find the end of the method
-	var next_method_line_index := text.find("func ", starting_index)
-	var method_end := -1
-
-	if next_method_line_index == -1:
-		# Backtrack empty lines from the end of the file
-		method_end = text.length() -1
-	else:
-		# Get the line before the next function line
-		method_end = text.rfind("\n", next_method_line_index)
-
-	# Backtrack to the last non-empty line
-	var last_non_empty_line_index := method_end
-	while last_non_empty_line_index > starting_index:
-		last_non_empty_line_index -= 1
-		# Remove spaces, tabs and newlines (whitespace) to check if the line really is empty
-		if text[last_non_empty_line_index].rstrip("\t\n "):
-			break # encountered a filled line
-
-	return last_non_empty_line_index +1
 
 
-func quote_string(string: String) -> String:
-	var settings: EditorSettings = EditorInterface.get_editor_settings()
-	if settings.get_setting("text_editor/completion/use_single_quotes"):
-		return "'%s'" % string
-	return "\"%s\"" % string
+
+
 
 
 func add_asset_overwrite_to_overwrites(vanilla_asset_path: String, asset_path: String) -> void:
@@ -358,8 +226,8 @@ func _init():
 
 	# Check if the overwrites script has the neccessary props
 	if (
-		not script_has_method(overwrites_script_path, "vanilla_file_paths") or
-		not script_has_method(overwrites_script_path, "overwrite_file_paths")
+		not ModToolUtils.script_has_method(overwrites_script_path, "vanilla_file_paths") or
+		not ModToolUtils.script_has_method(overwrites_script_path, "overwrite_file_paths")
 	):
 		ModToolUtils.output_error("The 'overwrites.gd' file has an unexpected format. To proceed, please delete the existing 'overwrites.gd' file and allow the tool to regenerate it automatically.")
 		return
@@ -386,14 +254,205 @@ func _init():
 	ModToolUtils.output_info('Added asset overwrite "%s" to mod "%s"' % [asset_path, overwrites_script_path.get_base_dir().get_file()])
 
 
-static func script_has_method(script_path: String, method: String) -> bool:
-	var script: Script = load(script_path)
+func add_context_action(context_menu: PopupMenu, script_paths: Array[String], options: ContextActionOptions) -> void:
+	context_menu.add_icon_item(
+				mod_tool_store.editor_base_control.get_theme_icon(options.icon, &"EditorIcons"),
+				"ModTool: %s" % options.title + ("s (%s)" % script_paths.size() if script_paths.size() > 1 else "")
+			)
+	context_menu.set_item_metadata(
+		context_menu.get_item_count() -1,
+		{ options.meta_key: script_paths }
+	)
+	context_menu.set_item_tooltip(
+		context_menu.get_item_count() -1,
+		"%s: \n%s" %
+		[options.tooltip, str(script_paths).trim_prefix("[").trim_suffix("]").replace(", ", "\n")]
+	)
 
-	for script_method in script.get_script_method_list():
-		if script_method.name == method:
-			return true
 
-	if method in script.source_code:
-		return true
+func add_script_extension_context_action(context_menu: PopupMenu, script_paths: Array[String]) -> void:
+	add_context_action(
+		context_menu,
+		script_paths,
+		ContextActionOptions.new(
+			&"ScriptExtend",
+			"Create Script Extension",
+			&"mod_tool_script_paths",
+			"Will add extensions for"
+		)
+	)
 
-	return false
+
+func add_restore_context_action(context_menu: PopupMenu, script_paths: Array[String]) -> void:
+	var script_paths_to_restore: Array[String] = script_paths.filter(
+		func(script_path): return mod_tool_store.hooked_scripts.has(script_path)
+	)
+
+	add_context_action(
+		context_menu,
+		script_paths_to_restore,
+		ContextActionOptions.new(
+			&"PlayStartBackwards",
+			"Restore non Hook Script",
+			&"mod_tool_restore_script_paths",
+			"Will restore the non hooked script for"
+		)
+	)
+
+
+func add_asset_override_context_action(context_menu: PopupMenu, script_paths: Array[String]) -> void:
+	add_context_action(
+		context_menu,
+		script_paths,
+		ContextActionOptions.new(
+			&"Override",
+			"Create Asset Overwrite",
+			&"mod_tool_override_paths",
+			"Will overwrite assets"
+		)
+	)
+
+
+func add_hooks_context_action(context_menu: PopupMenu, script_paths: Array[String]) -> void:
+	var script_paths_to_add_hooks: Array[String] = script_paths.filter(
+		func(script_path): return not mod_tool_store.hooked_scripts.has(script_path)
+	)
+
+	add_context_action(
+		context_menu,
+		script_paths_to_add_hooks,
+		ContextActionOptions.new(
+			&"ScriptCreate",
+			"Add Mod Hooks",
+			&"mod_tool_hook_script_paths",
+			"Will add mod hooks for"
+		)
+	)
+
+
+func handle_script_extension_creation(metadata: Dictionary) -> void:
+	var file_paths = metadata.mod_tool_script_paths
+	var mod_main_path := mod_tool_store.path_mod_dir.path_join("mod_main.gd")
+
+	for file_path in file_paths:
+		var extension_path := create_script_extension(file_path)
+		if extension_path:
+			add_script_extension_to_mod_main(extension_path)
+
+	# We navigate to the created script extension in `create_script_extension()`, so we should never
+	# instantly refresh the mod main script here. If we call `ModToolUtils.reload_script()`
+	# after this, it's possible that the `mod_main` content gets copied into the
+	# newly created extension script. If that script is then saved, we
+	# unintentionally overwrite the original script content.
+	mod_tool_store.pending_reloads.push_back(mod_main_path)
+
+	 #Switch to the script screen
+	EditorInterface.set_main_screen_editor("Script")
+
+
+func handle_override_creation(metadata: Dictionary) -> void:
+	var file_paths: Array[String] = metadata.mod_tool_override_paths
+	var current_script: GDScript
+	var overwrites_path := mod_tool_store.path_mod_dir.path_join("overwrites.gd")
+
+	for file_path in file_paths:
+		var asset_path := create_overwrite_asset(file_path)
+		if asset_path:
+			add_asset_overwrite_to_overwrites(file_path, asset_path)
+
+	current_script = EditorInterface.get_script_editor().get_current_script()
+
+	mod_tool_store.pending_reloads.push_back(overwrites_path)
+
+	if current_script.resource_path == overwrites_path:
+		ModToolUtils.reload_script(current_script, mod_tool_store)
+
+	#Switch to the script screen
+	EditorInterface.set_main_screen_editor("Script")
+
+
+func handle_mod_hook_creation(metadata: Dictionary) -> void:
+	var file_paths: Array[String] = metadata.mod_tool_hook_script_paths
+	var current_script: GDScript
+
+	for file_path in file_paths:
+		var error := ModToolHookGen.transform_one(file_path, mod_tool_store)
+
+		if not error == OK:
+			ModToolUtils.output_error("Error creating mod hooks for script at path: \"%s\" error: \"%s\" " % [file_path, error_string(error)])
+			return
+
+		mod_tool_store.pending_reloads.push_back(file_path)
+		current_script = EditorInterface.get_script_editor().get_current_script()
+
+		if current_script.resource_path == file_path:
+			ModToolUtils.reload_script(current_script, mod_tool_store)
+
+		ModToolUtils.output_info("Mod Hooks created for script at path: \"%s\"" % file_path)
+
+
+func handle_mod_hook_restore(metadata: Dictionary) -> void:
+	var file_paths: Array[String] = metadata.mod_tool_restore_script_paths
+	var current_script: GDScript
+
+	for file_path in file_paths:
+		var error := ModToolHookGen.restore(file_path, mod_tool_store)
+
+		if not error == OK:
+			ModToolUtils.output_error("ERROR: Restoring script: \"%s\" with error: \"%s\"" % [file_path, error_string(error)])
+			return
+
+		mod_tool_store.pending_reloads.push_back(file_path)
+		current_script = EditorInterface.get_script_editor().get_current_script()
+
+		if current_script.resource_path == file_path:
+			ModToolUtils.reload_script(current_script, mod_tool_store)
+
+
+func _on_file_tree_context_actions_about_to_popup(context_menu: PopupMenu, tree: Tree) -> void:
+	var selected := tree.get_next_selected(null)
+	if not selected:		# Empty space was clicked
+		return
+
+	# multiselection
+	var file_paths: Array[String] = []
+	while selected:
+		var file_path = selected.get_metadata(0)
+		if file_path is String:
+			file_paths.append(file_path)
+		selected = tree.get_next_selected(selected)
+
+	add_custom_context_actions(context_menu, file_paths)
+
+
+func _on_file_list_context_actions_about_to_popup(context_menu: PopupMenu, list: ItemList) -> void:
+	if not list.get_selected_items().size() > 0:		# Empty space was clicked
+		return
+
+	var file_paths := []
+	for item_index in list.get_selected_items():
+		var file_path = list.get_item_metadata(item_index)
+		if file_path is String:
+			file_paths.append(file_path)
+
+	add_custom_context_actions(context_menu, file_paths)
+
+
+func _on_file_system_context_menu_pressed(id: int, context_menu: PopupMenu) -> void:
+	var file_paths: PackedStringArray
+	var metadata = context_menu.get_item_metadata(id)
+	var current_script: GDScript
+
+	# Ensure that the metadata is actually set by the ModTool
+	# Since id and index of the item can always change
+	if metadata is Dictionary and metadata.has("mod_tool_script_paths"):
+		handle_script_extension_creation(metadata)
+
+	if metadata is Dictionary and metadata.has("mod_tool_override_paths"):
+		handle_override_creation(metadata)
+
+	if metadata is Dictionary and metadata.has("mod_tool_hook_script_paths"):
+		handle_mod_hook_creation(metadata)
+
+	if metadata is Dictionary and metadata.has("mod_tool_restore_script_paths"):
+		handle_mod_hook_restore(metadata)

--- a/addons/mod_tool/interface/hook_gen/hook_gen.gd
+++ b/addons/mod_tool/interface/hook_gen/hook_gen.gd
@@ -9,41 +9,15 @@ extends Window
 @onready var button_gen_start: Button = %ButtonGenStart
 
 
+
 func generate_hooks() -> void:
 	# Get all script not in addons or mods-unpacked
 	var all_script_file_paths := ModToolUtils.get_flat_view_dict("res://", "", [&"gd"], false, false, [&"addons", &"mods-unpacked"])
-	var mod_hook_preprocessor = _ModLoaderModHookPreProcessor.new()
-
-	# Create a backup of the vanilla script files
-	var project_dir_name := ProjectSettings.globalize_path("res://").get_base_dir().rsplit("/", true, 1)[1]
-	var parent_project_dir_path := ProjectSettings.globalize_path("res://").rsplit("/", true, 2)[0]
-	var backup_dir_path := "%s/%s" % [parent_project_dir_path, "%s-scripts_backup" % project_dir_name]
-	DirAccess.make_dir_recursive_absolute(backup_dir_path)
 
 	for script_file_path in all_script_file_paths:
-		var script_file_name := script_file_path.get_file()
-		ModToolUtils.file_copy(script_file_path, "%s/%s" % [backup_dir_path, script_file_name])
-
-	info_output.add_text("Script backup created at %s\n" % backup_dir_path)
-
-	# -- Start Mod Hook Generation --
-	mod_hook_preprocessor.process_begin()
-	info_output.add_text("Starting Mod Hook Generation..\n")
-
-	for script_file_path in all_script_file_paths:
-		var source_code := mod_hook_preprocessor.process_script(script_file_path)
-
-		var file := FileAccess.open(script_file_path, FileAccess.WRITE)
-
-		if not file:
-			info_output.add_text("ERROR: ACCESSING FILE: %s\n" % script_file_path)
-			return
-
-		# Clear existing file
-		file.resize(0)
-		# Write processed source_code to file
-		file.store_string(source_code)
-		file.close()
+		var error := ModToolHookGen.transform_one(script_file_path, mod_tool_store)
+		if not error == OK:
+			info_output.add_text("ERROR: Accessing file at path \"%s\" failed with error: %s \n" % [script_file_path, error_string(error)])
 
 	mod_tool_store.is_hook_generation_done = true
 	info_output.add_text("Mod Hook generation completed successfully!\n")

--- a/addons/mod_tool/interface/hook_gen/hook_gen.gd
+++ b/addons/mod_tool/interface/hook_gen/hook_gen.gd
@@ -3,11 +3,12 @@ class_name ModToolInterfaceHookGen
 extends Window
 
 
+signal hooks_exist_pressed
+
 @onready var mod_tool_store: ModToolStore = get_node_or_null("/root/ModToolStore")
 @onready var info_output: RichTextLabel = %InfoOutput
 @onready var restart: Window = %Restart
 @onready var button_gen_start: Button = %ButtonGenStart
-
 
 
 func generate_hooks() -> void:
@@ -15,13 +16,21 @@ func generate_hooks() -> void:
 	var all_script_file_paths := ModToolUtils.get_flat_view_dict("res://", "", [&"gd"], false, false, [&"addons", &"mods-unpacked"])
 
 	for script_file_path in all_script_file_paths:
+		if mod_tool_store.hooked_scripts.has(script_file_path):
+			info_output.add_text("Skipping - Hooks already exists for \"%s\" \n" % script_file_path)
+			continue
+
 		var error := ModToolHookGen.transform_one(script_file_path, mod_tool_store)
+
 		if not error == OK:
 			info_output.add_text("ERROR: Accessing file at path \"%s\" failed with error: %s \n" % [script_file_path, error_string(error)])
+		else:
+			info_output.add_text("Added Hooks for \"%s\" \n" % script_file_path)
 
 	mod_tool_store.is_hook_generation_done = true
 	info_output.add_text("Mod Hook generation completed successfully!\n")
 
+	mod_tool_store.save_store()
 	restart.show()
 
 
@@ -35,6 +44,7 @@ func _on_close_requested() -> void:
 
 
 func _on_button_restart_now_pressed() -> void:
+	await get_tree().create_timer(1.0).timeout
 	EditorInterface.restart_editor()
 
 
@@ -49,4 +59,5 @@ func _on_restart_close_requested() -> void:
 
 func _on_button_hooks_exist_pressed() -> void:
 	mod_tool_store.is_hook_generation_done = true
+	hooks_exist_pressed.emit()
 	hide()

--- a/addons/mod_tool/interface/hook_gen/hook_gen.gd
+++ b/addons/mod_tool/interface/hook_gen/hook_gen.gd
@@ -12,7 +12,7 @@ extends Window
 func generate_hooks() -> void:
 	# Get all script not in addons or mods-unpacked
 	var all_script_file_paths := ModToolUtils.get_flat_view_dict("res://", "", [&"gd"], false, false, [&"addons", &"mods-unpacked"])
-	var mod_hook_preprocessor = ModLoaderModHookPreProcessor.new()
+	var mod_hook_preprocessor = _ModLoaderModHookPreProcessor.new()
 
 	# Create a backup of the vanilla script files
 	var project_dir_name := ProjectSettings.globalize_path("res://").get_base_dir().rsplit("/", true, 1)[1]

--- a/addons/mod_tool/interface/hook_gen/hook_gen.gd
+++ b/addons/mod_tool/interface/hook_gen/hook_gen.gd
@@ -1,0 +1,78 @@
+@tool
+class_name ModToolInterfaceHookGen
+extends Window
+
+
+@onready var mod_tool_store: ModToolStore = get_node_or_null("/root/ModToolStore")
+@onready var info_output: RichTextLabel = %InfoOutput
+@onready var restart: Window = %Restart
+@onready var button_gen_start: Button = %ButtonGenStart
+
+
+func generate_hooks() -> void:
+	# Get all script not in addons or mods-unpacked
+	var all_script_file_paths := ModToolUtils.get_flat_view_dict("res://", "", [&"gd"], false, false, [&"addons", &"mods-unpacked"])
+	var mod_hook_preprocessor = ModLoaderModHookPreProcessor.new()
+
+	# Create a backup of the vanilla script files
+	var project_dir_name := ProjectSettings.globalize_path("res://").get_base_dir().rsplit("/", true, 1)[1]
+	var parent_project_dir_path := ProjectSettings.globalize_path("res://").rsplit("/", true, 2)[0]
+	var backup_dir_path := "%s/%s" % [parent_project_dir_path, "%s-scripts_backup" % project_dir_name]
+	DirAccess.make_dir_recursive_absolute(backup_dir_path)
+
+	for script_file_path in all_script_file_paths:
+		var script_file_name := script_file_path.get_file()
+		ModToolUtils.file_copy(script_file_path, "%s/%s" % [backup_dir_path, script_file_name])
+
+	info_output.add_text("Script backup created at %s\n" % backup_dir_path)
+
+	# -- Start Mod Hook Generation --
+	mod_hook_preprocessor.process_begin()
+	info_output.add_text("Starting Mod Hook Generation..\n")
+
+	for script_file_path in all_script_file_paths:
+		var source_code := mod_hook_preprocessor.process_script(script_file_path)
+
+		var file := FileAccess.open(script_file_path, FileAccess.WRITE)
+
+		if not file:
+			info_output.add_text("ERROR: ACCESSING FILE: %s\n" % script_file_path)
+			return
+
+		# Clear existing file
+		file.resize(0)
+		# Write processed source_code to file
+		file.store_string(source_code)
+		file.close()
+
+	mod_tool_store.is_hook_generation_done = true
+	info_output.add_text("Mod Hook generation completed successfully!\n")
+
+	restart.show()
+
+
+func _on_button_pressed() -> void:
+	button_gen_start.disabled = true
+	generate_hooks()
+
+
+func _on_close_requested() -> void:
+	hide()
+
+
+func _on_button_restart_now_pressed() -> void:
+	EditorInterface.restart_editor()
+
+
+func _on_button_restart_later_pressed() -> void:
+	restart.hide()
+	hide()
+
+
+func _on_restart_close_requested() -> void:
+	restart.hide()
+
+
+func _on_button_hooks_exist_pressed() -> void:
+	mod_tool_store.is_hook_generation_done = true
+	hide()

--- a/addons/mod_tool/interface/hook_gen/hook_gen.tscn
+++ b/addons/mod_tool/interface/hook_gen/hook_gen.tscn
@@ -1,0 +1,103 @@
+[gd_scene load_steps=2 format=3 uid="uid://cpll5clcnemyj"]
+
+[ext_resource type="Script" path="res://addons/mod_tool/interface/hook_gen/hook_gen.gd" id="1_lrahv"]
+
+[node name="HookGen" type="Window"]
+title = "Mod Dev Tool"
+initial_position = 1
+size = Vector2i(640, 375)
+wrap_controls = true
+script = ExtResource("1_lrahv")
+
+[node name="Restart" type="Window" parent="."]
+unique_name_in_owner = true
+title = "Mod Dev Tool"
+initial_position = 1
+size = Vector2i(440, 117)
+visible = false
+wrap_controls = true
+
+[node name="MarginContainer" type="MarginContainer" parent="Restart"]
+offset_right = 40.0
+offset_bottom = 40.0
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 10
+
+[node name="VBC" type="VBoxContainer" parent="Restart/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="LabelInfoText" type="RichTextLabel" parent="Restart/MarginContainer/VBC"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+text = "Successfully generated mod hooks. 
+To start modding, a restart of the editor is required."
+fit_content = true
+
+[node name="HBC" type="HBoxContainer" parent="Restart/MarginContainer/VBC"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_constants/separation = 30
+
+[node name="ButtonRestartNow" type="Button" parent="Restart/MarginContainer/VBC/HBC"]
+layout_mode = 2
+text = "Restart Now"
+
+[node name="ButtonRestartLater" type="Button" parent="Restart/MarginContainer/VBC/HBC"]
+layout_mode = 2
+text = "Restart Later"
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+offset_right = 40.0
+offset_bottom = 40.0
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 15
+
+[node name="VBC" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="LabelInfoText" type="RichTextLabel" parent="MarginContainer/VBC"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+text = "It looks like modding hooks haven't been generated yet.
+
+This will modify all existing scripts in the project, so please make sure to save your files before continuing.
+
+The process may take some time depending on the number of scripts."
+fit_content = true
+
+[node name="VBC" type="VBoxContainer" parent="MarginContainer/VBC"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="ButtonGenStart" type="Button" parent="MarginContainer/VBC/VBC"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Generate mod hooks"
+
+[node name="ButtonHooksExist" type="Button" parent="MarginContainer/VBC/VBC"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Hooks already exist don't show this again"
+
+[node name="VBC2" type="VBoxContainer" parent="MarginContainer/VBC"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="InfoOutput" type="RichTextLabel" parent="MarginContainer/VBC/VBC2"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(600, 100)
+layout_mode = 2
+scroll_following = true
+
+[connection signal="close_requested" from="." to="." method="_on_close_requested"]
+[connection signal="close_requested" from="Restart" to="." method="_on_restart_close_requested"]
+[connection signal="pressed" from="Restart/MarginContainer/VBC/HBC/ButtonRestartNow" to="." method="_on_button_restart_now_pressed"]
+[connection signal="pressed" from="Restart/MarginContainer/VBC/HBC/ButtonRestartLater" to="." method="_on_button_restart_later_pressed"]
+[connection signal="pressed" from="MarginContainer/VBC/VBC/ButtonGenStart" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBC/VBC/ButtonHooksExist" to="." method="_on_button_hooks_exist_pressed"]

--- a/addons/mod_tool/interface/hook_restore/hook_restore.gd
+++ b/addons/mod_tool/interface/hook_restore/hook_restore.gd
@@ -1,0 +1,59 @@
+@tool
+class_name ModToolInterfaceHookRestore
+extends Window
+
+
+@onready var mod_tool_store: ModToolStore = get_node_or_null("/root/ModToolStore")
+@onready var info_output: RichTextLabel = %InfoOutput
+@onready var restart: Window = %Restart
+@onready var button_restore_start: Button = %ButtonRestoreStart
+
+
+func start_restore() -> void:
+	# Get all script not in addons or mods-unpacked
+	var all_script_file_paths := ModToolUtils.get_flat_view_dict("res://", "", [&"gd"], false, false, [&"addons", &"mods-unpacked"])
+
+	var encountered_error := false
+
+	for script_path in mod_tool_store.hooked_scripts.keys():
+		var error := ModToolHookGen.restore(script_path, mod_tool_store)
+
+		if not error == OK:
+			encountered_error = true
+			info_output.add_text("ERROR: Accessing file at path \"%s\" failed with error: %s \n" % [script_path, error_string(error)])
+			break
+
+		info_output.add_text("Restored \"%s\" \n" % script_path)
+
+	if encountered_error:
+		info_output.add_text("ERROR: Restore aborted.\n")
+	else:
+		mod_tool_store.is_hook_generation_done = false
+		info_output.add_text("Restore completed successfully!\n")
+
+		mod_tool_store.save_store()
+
+		restart.show()
+
+
+func _on_close_requested() -> void:
+	hide()
+
+
+func _on_button_restart_now_pressed() -> void:
+	await get_tree().create_timer(1.0).timeout
+	EditorInterface.restart_editor()
+
+
+func _on_button_restart_later_pressed() -> void:
+	restart.hide()
+	hide()
+
+
+func _on_restart_close_requested() -> void:
+	restart.hide()
+
+
+func _on_button_restore_start_pressed() -> void:
+	button_restore_start.disabled = true
+	start_restore()

--- a/addons/mod_tool/interface/hook_restore/hook_restore.tscn
+++ b/addons/mod_tool/interface/hook_restore/hook_restore.tscn
@@ -1,13 +1,13 @@
-[gd_scene load_steps=2 format=3 uid="uid://cpll5clcnemyj"]
+[gd_scene load_steps=2 format=3 uid="uid://camcc83bvu086"]
 
-[ext_resource type="Script" path="res://addons/mod_tool/interface/hook_gen/hook_gen.gd" id="1_lrahv"]
+[ext_resource type="Script" path="res://addons/mod_tool/interface/hook_restore/hook_restore.gd" id="1_wq3ld"]
 
-[node name="HookGen" type="Window"]
+[node name="HookRestore" type="Window"]
 title = "Mod Dev Tool"
 initial_position = 1
 size = Vector2i(640, 375)
 wrap_controls = true
-script = ExtResource("1_lrahv")
+script = ExtResource("1_wq3ld")
 
 [node name="Restart" type="Window" parent="."]
 unique_name_in_owner = true
@@ -28,12 +28,13 @@ theme_override_constants/margin_bottom = 10
 [node name="VBC" type="VBoxContainer" parent="Restart/MarginContainer"]
 layout_mode = 2
 theme_override_constants/separation = 20
+alignment = 1
 
 [node name="LabelInfoText" type="RichTextLabel" parent="Restart/MarginContainer/VBC"]
 custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
-text = "Successfully generated mod hooks. 
-To start modding, a restart of the editor is required."
+text = "Successfully restored all scripts. 
+A restart of the editor is required."
 fit_content = true
 
 [node name="HBC" type="HBoxContainer" parent="Restart/MarginContainer/VBC"]
@@ -67,7 +68,7 @@ theme_override_constants/separation = 20
 [node name="LabelInfoText" type="RichTextLabel" parent="MarginContainer/VBC"]
 custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
-text = "This will modify all existing scripts in the project, so please make sure to save your files before continuing.
+text = "This will restore all scripts to their state before mod hooks were added. Any changes made to these scripts will be lost!
 
 The process may take some time depending on the number of scripts."
 fit_content = true
@@ -76,15 +77,10 @@ fit_content = true
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="ButtonGenStart" type="Button" parent="MarginContainer/VBC/VBC"]
+[node name="ButtonRestoreStart" type="Button" parent="MarginContainer/VBC/VBC"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Generate mod hooks"
-
-[node name="ButtonHooksExist" type="Button" parent="MarginContainer/VBC/VBC"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Hooks already exist"
+text = "Start Restore"
 
 [node name="VBC2" type="VBoxContainer" parent="MarginContainer/VBC"]
 layout_mode = 2
@@ -101,5 +97,4 @@ scroll_following = true
 [connection signal="close_requested" from="Restart" to="." method="_on_restart_close_requested"]
 [connection signal="pressed" from="Restart/MarginContainer/VBC/HBC/ButtonRestartNow" to="." method="_on_button_restart_now_pressed"]
 [connection signal="pressed" from="Restart/MarginContainer/VBC/HBC/ButtonRestartLater" to="." method="_on_button_restart_later_pressed"]
-[connection signal="pressed" from="MarginContainer/VBC/VBC/ButtonGenStart" to="." method="_on_button_pressed"]
-[connection signal="pressed" from="MarginContainer/VBC/VBC/ButtonHooksExist" to="." method="_on_button_hooks_exist_pressed"]
+[connection signal="pressed" from="MarginContainer/VBC/VBC/ButtonRestoreStart" to="." method="_on_button_restore_start_pressed"]

--- a/addons/mod_tool/interface/panel/tools_panel.gd
+++ b/addons/mod_tool/interface/panel/tools_panel.gd
@@ -22,6 +22,9 @@ var log_dock_button: Button
 @onready var export_path := $"%ExportPath"
 @onready var file_dialog := $"%FileDialog"
 @onready var hook_gen: ModToolInterfaceHookGen = %HookGen
+@onready var hook_restore: ModToolInterfaceHookRestore = %HookRestore
+@onready var button_add_hooks: Button = %AddHooks
+@onready var button_restore: Button = %Restore
 
 
 func _ready() -> void:
@@ -30,9 +33,10 @@ func _ready() -> void:
 	get_log_nodes()
 
 	if mod_tool_store:
-		if not mod_tool_store.is_hook_generation_done:
-			hook_gen.show()
-
+		if mod_tool_store.is_hook_generation_done:
+			button_add_hooks.hide()
+		else:
+			button_restore.hide()
 		# Load manifest.json file
 		if _ModLoaderFile.file_exists(mod_tool_store.path_manifest):
 			manifest_editor.load_manifest()
@@ -187,3 +191,16 @@ func _on_FileDialog_dir_selected(dir: String) -> void:
 	mod_tool_store.path_export_dir = dir
 	export_path.input_text = dir
 	file_dialog.hide()
+
+
+func _on_add_hooks_pressed() -> void:
+	hook_gen.show()
+
+
+func _on_restore_pressed() -> void:
+	hook_restore.show()
+
+
+func _on_hook_gen_hooks_exist_pressed() -> void:
+	button_add_hooks.hide()
+	button_restore.show()

--- a/addons/mod_tool/interface/panel/tools_panel.gd
+++ b/addons/mod_tool/interface/panel/tools_panel.gd
@@ -21,6 +21,7 @@ var log_dock_button: Button
 @onready var manifest_editor := $"%Manifest Editor"
 @onready var export_path := $"%ExportPath"
 @onready var file_dialog := $"%FileDialog"
+@onready var hook_gen: ModToolInterfaceHookGen = %HookGen
 
 
 func _ready() -> void:
@@ -28,10 +29,14 @@ func _ready() -> void:
 
 	get_log_nodes()
 
-	# Load manifest.json file
-	if mod_tool_store and _ModLoaderFile.file_exists(mod_tool_store.path_manifest):
-		manifest_editor.load_manifest()
-		manifest_editor.update_ui()
+	if mod_tool_store:
+		if not mod_tool_store.is_hook_generation_done:
+			hook_gen.show()
+
+		# Load manifest.json file
+		if _ModLoaderFile.file_exists(mod_tool_store.path_manifest):
+			manifest_editor.load_manifest()
+			manifest_editor.update_ui()
 
 	_update_ui()
 

--- a/addons/mod_tool/interface/panel/tools_panel.tscn
+++ b/addons/mod_tool/interface/panel/tools_panel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://jgayt8758anm"]
+[gd_scene load_steps=13 format=3 uid="uid://jgayt8758anm"]
 
 [ext_resource type="PackedScene" uid="uid://glui2s46v4x4" path="res://addons/mod_tool/interface/create_mod/create_mod.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://hpefgw6k5qpq" path="res://addons/mod_tool/interface/manifest_editor/manifest_editor.tscn" id="2"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://du17jjwqtopix" path="res://addons/mod_tool/interface/global/directory_selection/select_directory.tscn" id="7"]
 [ext_resource type="PackedScene" path="res://addons/mod_tool/interface/global/input_string_with_button.tscn" id="8"]
 [ext_resource type="PackedScene" uid="uid://cpll5clcnemyj" path="res://addons/mod_tool/interface/hook_gen/hook_gen.tscn" id="8_k13cs"]
+[ext_resource type="PackedScene" uid="uid://camcc83bvu086" path="res://addons/mod_tool/interface/hook_restore/hook_restore.tscn" id="9_2cgta"]
 
 [sub_resource type="StyleBoxEmpty" id="14"]
 
@@ -57,6 +58,7 @@ layout_mode = 2
 
 [node name="HSplit" type="HSplitContainer" parent="Panel/VSplit/Export"]
 layout_mode = 2
+theme_override_constants/separation = 10
 
 [node name="Console" type="VBoxContainer" parent="Panel/VSplit/Export/HSplit"]
 visible = false
@@ -99,6 +101,7 @@ size_flags_stretch_ratio = 0.5
 [node name="VBox" type="VBoxContainer" parent="Panel/VSplit/Export/HSplit/Settings"]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/separation = 5
 
 [node name="Category" type="LineEdit" parent="Panel/VSplit/Export/HSplit/Settings/VBox"]
 layout_mode = 2
@@ -148,6 +151,7 @@ hint_text = "The directory to which the final mod zip is exported."
 
 [node name="Align" type="HBoxContainer" parent="Panel/VSplit/Export/HSplit/Settings/VBox"]
 layout_mode = 2
+theme_override_constants/separation = 10
 alignment = 2
 
 [node name="ExportStatus" type="Label" parent="Panel/VSplit/Export/HSplit/Settings/VBox/Align"]
@@ -162,6 +166,7 @@ text = "Export Mod"
 [node name="VBox" type="VBoxContainer" parent="Panel/VSplit/Export/HSplit"]
 custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
+theme_override_constants/separation = 5
 
 [node name="Category" type="LineEdit" parent="Panel/VSplit/Export/HSplit/VBox"]
 layout_mode = 2
@@ -182,6 +187,16 @@ text = "Create new Mod"
 layout_mode = 2
 text = "Connect existing Mod"
 
+[node name="AddHooks" type="Button" parent="Panel/VSplit/Export/HSplit/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Add Hooks to all Scripts"
+
+[node name="Restore" type="Button" parent="Panel/VSplit/Export/HSplit/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Restore non Hooked Scripts"
+
 [node name="CreateMod" parent="." instance=ExtResource("1")]
 unique_name_in_owner = true
 initial_position = 2
@@ -200,6 +215,10 @@ visible = false
 unique_name_in_owner = true
 visible = false
 
+[node name="HookRestore" parent="." instance=ExtResource("9_2cgta")]
+unique_name_in_owner = true
+visible = false
+
 [node name="FileDialog" type="FileDialog" parent="."]
 unique_name_in_owner = true
 title = "Open a Directory"
@@ -215,6 +234,9 @@ access = 2
 [connection signal="pressed" from="Panel/VSplit/Export/HSplit/Settings/VBox/Align/Export" to="." method="_on_export_pressed"]
 [connection signal="pressed" from="Panel/VSplit/Export/HSplit/VBox/CreateMod" to="." method="_on_export_settings_create_new_mod_pressed"]
 [connection signal="pressed" from="Panel/VSplit/Export/HSplit/VBox/ConnectMod" to="." method="_on_ConnectMod_pressed"]
+[connection signal="pressed" from="Panel/VSplit/Export/HSplit/VBox/AddHooks" to="." method="_on_add_hooks_pressed"]
+[connection signal="pressed" from="Panel/VSplit/Export/HSplit/VBox/Restore" to="." method="_on_restore_pressed"]
 [connection signal="mod_dir_created" from="CreateMod" to="." method="_on_CreateMod_mod_dir_created"]
 [connection signal="dir_selected" from="SelectMod" to="." method="_on_SelectMod_dir_selected"]
+[connection signal="hooks_exist_pressed" from="HookGen" to="." method="_on_hook_gen_hooks_exist_pressed"]
 [connection signal="dir_selected" from="FileDialog" to="." method="_on_FileDialog_dir_selected"]

--- a/addons/mod_tool/interface/panel/tools_panel.tscn
+++ b/addons/mod_tool/interface/panel/tools_panel.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=11 format=3 uid="uid://jgayt8758anm"]
+[gd_scene load_steps=12 format=3 uid="uid://jgayt8758anm"]
 
 [ext_resource type="PackedScene" uid="uid://glui2s46v4x4" path="res://addons/mod_tool/interface/create_mod/create_mod.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://hpefgw6k5qpq" path="res://addons/mod_tool/interface/manifest_editor/manifest_editor.tscn" id="2"]
 [ext_resource type="Script" path="res://addons/mod_tool/interface/panel/tools_panel.gd" id="3"]
-[ext_resource type="PackedScene" path="res://addons/mod_tool/interface/global/input_string.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://icwo58h0rdb5" path="res://addons/mod_tool/interface/global/input_string.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://dyunxqcmy4esi" path="res://addons/mod_tool/interface/global/input_options.tscn" id="6"]
 [ext_resource type="PackedScene" uid="uid://du17jjwqtopix" path="res://addons/mod_tool/interface/global/directory_selection/select_directory.tscn" id="7"]
 [ext_resource type="PackedScene" path="res://addons/mod_tool/interface/global/input_string_with_button.tscn" id="8"]
+[ext_resource type="PackedScene" uid="uid://cpll5clcnemyj" path="res://addons/mod_tool/interface/hook_gen/hook_gen.tscn" id="8_k13cs"]
 
 [sub_resource type="StyleBoxEmpty" id="14"]
 
@@ -45,9 +46,11 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("14")
+current_tab = 0
 
 [node name="Manifest Editor" parent="Panel/VSplit/TabContainer" instance=ExtResource("2")]
 layout_mode = 2
+metadata/_tab_index = 0
 
 [node name="Export" type="PanelContainer" parent="Panel/VSplit"]
 layout_mode = 2
@@ -128,7 +131,6 @@ Format: Namespace-ModName
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-input_options = PackedStringArray("Steam Workshop", "Thunderstore")
 is_required = true
 key = "export_type"
 label_text = "Export Type"
@@ -191,6 +193,10 @@ unique_name_in_owner = true
 visible = false
 
 [node name="SelectModTemplate" parent="." instance=ExtResource("7")]
+unique_name_in_owner = true
+visible = false
+
+[node name="HookGen" parent="." instance=ExtResource("8_k13cs")]
 unique_name_in_owner = true
 visible = false
 

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -17,8 +17,6 @@ static func transform_one(path: String, mod_tool_store: ModToolStore) -> Error:
 		var error := file.get_error()
 		return error
 
-	# Clear existing file
-	file.resize(0)
 	# Write processed source_code to file
 	file.store_string(source_code_processed)
 	file.close()

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -57,5 +57,5 @@ static func clear_mod_hook_preprocessor_hashmap(path: String, mod_tool_store: Mo
 	var script: GDScript = load(path)
 
 	for method in script.get_script_method_list():
-		mod_tool_store.mod_hook_preprocessor.hashmap.erase(ModLoaderMod.get_hook_hash(path, method.name, true))
-		mod_tool_store.mod_hook_preprocessor.hashmap.erase(ModLoaderMod.get_hook_hash(path, method.name, false))
+		mod_tool_store.mod_hook_preprocessor.hashmap.erase(_ModLoaderHooks.get_hook_hash(path, method.name, true))
+		mod_tool_store.mod_hook_preprocessor.hashmap.erase(_ModLoaderHooks.get_hook_hash(path, method.name, false))

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -1,0 +1,61 @@
+@tool
+class_name ModToolHookGen
+extends RefCounted
+
+
+static func transform_one(path: String, mod_tool_store: ModToolStore) -> Error:
+	var source_code_processed := mod_tool_store.mod_hook_preprocessor.process_script(path)
+
+	# Create a backup of the vanilla script files
+	ModToolUtils.file_copy(path, "%s/%s" % [mod_tool_store.path_script_backup_dir, path.trim_prefix("res://")])
+
+	var file := FileAccess.open(path, FileAccess.WRITE)
+
+	if not file:
+		var error := file.get_error()
+		return error
+
+	# Clear existing file
+	file.resize(0)
+	# Write processed source_code to file
+	file.store_string(source_code_processed)
+	file.close()
+
+	mod_tool_store.hooked_scripts[path] = true
+
+	return OK
+
+
+static func restore(path: String, mod_tool_store: ModToolStore) -> Error:
+	var backup_path := "%s/%s" % [mod_tool_store.path_script_backup_dir, path.trim_prefix("res://")]
+
+	var backup_file := FileAccess.open(backup_path, FileAccess.READ)
+
+	if not backup_file:
+		return backup_file.get_error()
+
+	var restored_source := backup_file.get_as_text()
+
+	var file := FileAccess.open(path, FileAccess.WRITE)
+
+	if not file:
+		return file.get_error()
+
+	# Clear existing file
+	file.resize(0)
+	# Write processed source_code to file
+	file.store_string(restored_source)
+	file.close()
+
+	mod_tool_store.hooked_scripts.erase(path)
+	clear_mod_hook_preprocessor_hashmap(path, mod_tool_store)
+
+	return OK
+
+
+static func clear_mod_hook_preprocessor_hashmap(path: String, mod_tool_store: ModToolStore) -> void:
+	var script: GDScript = load(path)
+
+	for method in script.get_script_method_list():
+		mod_tool_store.mod_hook_preprocessor.hashmap.erase(ModLoaderMod.get_hook_hash(path, method.name, true))
+		mod_tool_store.mod_hook_preprocessor.hashmap.erase(ModLoaderMod.get_hook_hash(path, method.name, false))

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -5,9 +5,11 @@ extends RefCounted
 
 static func transform_one(path: String, mod_tool_store: ModToolStore) -> Error:
 	var source_code_processed := mod_tool_store.mod_hook_preprocessor.process_script(path)
+	var backup_path := "%s/%s" % [mod_tool_store.path_script_backup_dir, path.trim_prefix("res://")]
 
 	# Create a backup of the vanilla script files
-	ModToolUtils.file_copy(path, "%s/%s" % [mod_tool_store.path_script_backup_dir, path.trim_prefix("res://")])
+	if not FileAccess.file_exists(backup_path):
+		ModToolUtils.file_copy(path, backup_path)
 
 	var file := FileAccess.open(path, FileAccess.WRITE)
 
@@ -28,7 +30,6 @@ static func transform_one(path: String, mod_tool_store: ModToolStore) -> Error:
 
 static func restore(path: String, mod_tool_store: ModToolStore) -> Error:
 	var backup_path := "%s/%s" % [mod_tool_store.path_script_backup_dir, path.trim_prefix("res://")]
-
 	var backup_file := FileAccess.open(backup_path, FileAccess.READ)
 
 	if not backup_file:
@@ -48,6 +49,7 @@ static func restore(path: String, mod_tool_store: ModToolStore) -> Error:
 	file.close()
 
 	mod_tool_store.hooked_scripts.erase(path)
+
 	clear_mod_hook_preprocessor_hashmap(path, mod_tool_store)
 
 	return OK

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -42,8 +42,6 @@ static func restore(path: String, mod_tool_store: ModToolStore) -> Error:
 	if not file:
 		return file.get_error()
 
-	# Clear existing file
-	file.resize(0)
 	# Write processed source_code to file
 	file.store_string(restored_source)
 	file.close()

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -55,5 +55,4 @@ static func clear_mod_hook_preprocessor_hashmap(path: String, mod_tool_store: Mo
 	var script: GDScript = load(path)
 
 	for method in script.get_script_method_list():
-		mod_tool_store.mod_hook_preprocessor.hashmap.erase(_ModLoaderHooks.get_hook_hash(path, method.name, true))
-		mod_tool_store.mod_hook_preprocessor.hashmap.erase(_ModLoaderHooks.get_hook_hash(path, method.name, false))
+		mod_tool_store.mod_hook_preprocessor.hashmap.erase(_ModLoaderHooks.get_hook_hash(path, method.name))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ecf4a447-cddb-4a0b-9e49-d3cd40f04aca)


## Todo
- [x] Add restore tool
   - [x] Add right click script restore
   - [x] Add full project restore
- [x] Move non UI stuff out of the *hook_gen.gd* Window script
- [x] One global instance of `_ModLoaderModHookPreProcessor` in `ModToolStore`
- [x] Add file system context action to generate hooks for a specific file
   - [x] Check if a script is transformed already
 - [x] Deal with the `ModLoaderModHookPreProcessor` `hashmap`
    - [x] I have to remove the entry for a script if it is restored
    - [x] Store the hashmap in `ModToolStore`
- [x] Currently, I get all these errors after transforming a script:
```text
  res://addons/mod_loader/api/log.gd:396 - Invalid access to property or key 'ml_options' on a base object of type 'Node (mod_loader_store.gd)'.
  res://addons/mod_loader/api/log.gd:416 - Invalid access to property or key 'logged_messages' on a base object of type 'Node (mod_loader_store.gd)'.
  res://addons/mod_loader/api/log.gd:408 - Invalid access to property or key 'ml_options' on a base object of type 'Node (mod_loader_store.gd)'.
  res://addons/mod_loader/api/log.gd:396 - Invalid access to property or key 'ml_options' on a base object of type 'Node (mod_loader_store.gd)'.
  res://addons/mod_loader/api/log.gd:416 - Invalid access to property or key 'logged_messages' on a base object of type 'Node (mod_loader_store.gd)'.
  res://addons/mod_loader/api/log.gd:408 - Invalid access to property or key 'ml_options' on a base object of type 'Node (mod_loader_store.gd)'.
```
 - [x] Move the Full Hook Conversion to the Mod Tool panel ( Don't do the window on startup thing - to annoying )

## Known Issues

- If hooks for a script are restored and then generated again without saving the script in between, the hooks are doubled.
   - Not a major issue because the script can easily be restored again