### PR TITLE
refactor: :recycle: non static `ModManifest`

### DIFF
--- a/addons/mod_tool/interface/create_mod/create_mod.gd
+++ b/addons/mod_tool/interface/create_mod/create_mod.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 
 func add_mod() -> void:
 	# Validate mod-id
-	if not ModManifest.is_mod_id_valid(mod_tool_store.name_mod_dir, mod_tool_store.name_mod_dir, "", true):
+	if not mod_tool_store.manifest_data.is_mod_id_valid(mod_tool_store.name_mod_dir, mod_tool_store.name_mod_dir, "", true):
 		ModToolUtils.output_error('Invalid name or namespace: "%s". You may only use letters, numbers, underscores and at least 3 characters for each.' % mod_tool_store.name_mod_dir)
 		return
 
@@ -115,17 +115,17 @@ func get_template_options() -> Array[String]:
 
 
 func _on_Namespace_value_changed(new_value: String, input_node: ModToolInterfaceInputString) -> void:
-	input_node.validate(ModManifest.is_name_or_namespace_valid(new_value, true))
+	input_node.validate(mod_tool_store.manifest_data.is_name_or_namespace_valid(new_value, true))
 	mod_id.input_text = "%s-%s" % [mod_namespace.get_input_value(), mod_name.get_input_value()]
 
 
 func _on_ModName_value_changed(new_value: String, input_node: ModToolInterfaceInputString) -> void:
-	input_node.validate(ModManifest.is_name_or_namespace_valid(new_value, true))
+	input_node.validate(mod_tool_store.manifest_data.is_name_or_namespace_valid(new_value, true))
 	mod_id.input_text = "%s-%s" % [mod_namespace.get_input_value(), mod_name.get_input_value()]
 
 
 func _on_ModId_value_changed(new_value: String, input_node: ModToolInterfaceInputString) -> void:
-	input_node.validate(ModManifest.is_mod_id_valid(new_value, new_value, "", true))
+	input_node.validate(mod_tool_store.manifest_data.is_mod_id_valid(new_value, new_value, "", true))
 	mod_tool_store.name_mod_dir = new_value
 
 

--- a/addons/mod_tool/scripts/hook_gen.gd
+++ b/addons/mod_tool/scripts/hook_gen.gd
@@ -4,7 +4,7 @@ extends RefCounted
 
 
 static func transform_one(path: String, mod_tool_store: ModToolStore) -> Error:
-	var source_code_processed := mod_tool_store.mod_hook_preprocessor.process_script(path)
+	var source_code_processed := mod_tool_store.mod_hook_preprocessor.process_script(path, true)
 	var backup_path := "%s/%s" % [mod_tool_store.path_script_backup_dir, path.trim_prefix("res://")]
 
 	# Create a backup of the vanilla script files


### PR DESCRIPTION
We can use the manifest instance that we already have in the tool store.

Necessary because of 
- https://github.com/GodotModding/godot-mod-loader/pull/485
