### PR TITLE
fix: :bug: fall back to template manifest

### DIFF
--- a/addons/mod_tool/interface/panel/tools_panel.gd
+++ b/addons/mod_tool/interface/panel/tools_panel.gd
@@ -41,6 +41,10 @@ func _ready() -> void:
 		if _ModLoaderFile.file_exists(mod_tool_store.path_manifest):
 			manifest_editor.load_manifest()
 			manifest_editor.update_ui()
+		else:
+			# Create empty Manifest
+			var template_manifest_data := _ModLoaderFile.get_json_as_dict("res://addons/mod_tool/templates/minimal/manifest.json")
+			mod_tool_store.manifest_data = ModManifest.new(template_manifest_data, "")
 
 	_update_ui()
 

--- a/addons/mod_tool/interface/panel/tools_panel.gd
+++ b/addons/mod_tool/interface/panel/tools_panel.gd
@@ -42,7 +42,7 @@ func _ready() -> void:
 			manifest_editor.load_manifest()
 			manifest_editor.update_ui()
 		else:
-			# Create empty Manifest
+			# Load template Manifest
 			var template_manifest_data := _ModLoaderFile.get_json_as_dict("res://addons/mod_tool/templates/minimal/manifest.json")
 			mod_tool_store.manifest_data = ModManifest.new(template_manifest_data, "")
 


### PR DESCRIPTION
If there is no manifest path stored, mod creation breaks because no Manifest instance is created. To fix this, the manifest of the template mod is now loaded.