### PR TITLE
refactor: :recycle: delete a previously exported mod zip

### DIFF
--- a/addons/mod_tool/scripts/build_zip.gd
+++ b/addons/mod_tool/scripts/build_zip.gd
@@ -31,6 +31,10 @@ func build_zip(mod_tool_store: ModToolStore) -> void:
 		# Copy mod_file to temp folder
 		ModToolUtils.file_copy(path_mod_file, path_zip_file)
 
+	# Delete the zip if it already exists
+	if _ModLoaderFile.file_exists(mod_tool_store.path_global_final_zip):
+		_ModLoaderFile.remove_file(mod_tool_store.path_global_final_zip)
+
 	# Zip that folder
 	var output: String
 	if OS.has_feature("Windows"):


### PR DESCRIPTION
Alternatively, the -Update option can be passed to the PowerShell command on Windows.  

Adding an option to let the user decide whether the zip should be updated or deleted is probably the way to go.