### PR TITLE
fix icon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Godot Mod Loader Development Tool
 
-<img alt="Godot Mod Loader Devtool Logo" src="https://github.com/GodotModding/godot-mod-tool/blob/4.x-dev/icon.png" width="256" />
+<img alt="Godot Mod Loader Devtool Logo" src="./icon.png" width="256" />
 
 <br />
 <br />

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Godot Mod Loader Development Tool
 
-<img alt="Godot Mod Loader Devtool Logo" src="https://github.com/GodotModding/godot-mod-tool/blob/main/icon.png" width="256" />
+<img alt="Godot Mod Loader Devtool Logo" src="https://github.com/GodotModding/godot-mod-tool/blob/4.x-dev/icon.png" width="256" />
 
 <br />
 <br />


### PR DESCRIPTION
Icon currently returns a 404 because the main branch got deleted.