### PR TITLE
Automatically fill in the mod ID in the template when creating a mod

### DIFF
--- a/addons/mod_tool/interface/create_mod/create_mod.gd
+++ b/addons/mod_tool/interface/create_mod/create_mod.gd
@@ -56,7 +56,7 @@ func add_mod() -> void:
 		ModToolUtils.output_info("Added base mod files to " + mod_tool_store.path_mod_dir)
 
 		# Replace the mod ID in mod_main.gd with the specified one
-		# However, keep comments mentioning "(AuthorName-ModName)
+		# However, keep comments mentioning "(AuthorName-ModName)"
 		var mod_main_script: GDScript = load(mod_tool_store.path_mod_dir.path_join("mod_main.gd"))
 		mod_main_script.source_code = mod_main_script.source_code.replace('"AuthorName-ModName', '"%s' % mod_tool_store.name_mod_dir)
 		mod_main_script.source_code = mod_main_script.source_code.replace('/AuthorName-ModName', '/%s' % mod_tool_store.name_mod_dir)

--- a/addons/mod_tool/interface/create_mod/create_mod.gd
+++ b/addons/mod_tool/interface/create_mod/create_mod.gd
@@ -55,8 +55,14 @@ func add_mod() -> void:
 		# Output info
 		ModToolUtils.output_info("Added base mod files to " + mod_tool_store.path_mod_dir)
 
+		# Replace the mod ID in mod_main.gd with the specified one
+		# However, keep comments mentioning "(AuthorName-ModName)
+		var mod_main_script: GDScript = load(mod_tool_store.path_mod_dir.path_join("mod_main.gd"))
+		mod_main_script.source_code = mod_main_script.source_code.replace('"AuthorName-ModName', '"%s' % mod_tool_store.name_mod_dir)
+		mod_main_script.source_code = mod_main_script.source_code.replace('/AuthorName-ModName', '/%s' % mod_tool_store.name_mod_dir)
+		ResourceSaver.save(mod_main_script, mod_main_script.resource_path)
+
 		# Open mod_main.gd in the code editor
-		var mod_main_script := load(mod_tool_store.path_mod_dir.path_join("mod_main.gd"))
 		EditorInterface.edit_script(mod_main_script)
 		EditorInterface.set_main_screen_editor("Script")
 


### PR DESCRIPTION
This has been bugging me for a while. `AuthorName-ModName` strings in the mod template now get filled in when creating a mod. (I know at least one person who didn't know that you had to do this manually and then ran into errors.)